### PR TITLE
Add contributions steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,14 @@ To disclose a security issue to our team. (security@classicpress.net)
 ## Support
 This repository is most suitable for development but for the little while will use it for support. We shall add a support tag to your issue. However, this might take a little longer to get response.
 
-## Contributing to WooCommerce
+## Contributing to ClassicCommerce
 If you have a patch or have stumbled upon an issue with WooCommerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md) for more information how you can do this.
+
+### Submit a PR
+Start by cloning this repo into your staging site plugins folder via the terminal or command prompt using:
+- Run `git clone https://github.com/ClassicPress-research/classic-commerce`
+- Run `cd classic-commerce`
+- Run `composer install`
+- Run `npm install`
+- Run `npm scripts build-watch` or `npm scripts build` as you develop.
+- Push your PR commits and changes to the **develop** branch.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Remove jetpack installation on initial activation of CC plugin. 

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Remove all requests to install jetpack. However, some of the services depend on jetpack that come with the initial installation of CC like WooCommerce Services that supports a number of other services like the Woo premium services.

Closes https://github.com/ClassicPress-research/classic-commerce/issues/4 .

### How to test the changes in this Pull Request:

1. Install the unzip version into your plugins folder
2. Activate the plugin and run the wizard.

### Other information:
This change however leaves a notice pop up for when a customer requires to install Jetpack for WooCommerce services and premium services. Should we also remove this?

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Removes jetpack and related functions - `wp_setup_active()`, `get_all_activate_errors()`, `wc_setup_activate_save()`
DB options do not exist - woocommerce_setup_background_installing_jetpack, woocommerce_setup_jetpack_opted_in

