### PR TITLE
Update email settings page

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -133,7 +133,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'css'         => 'width:300px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',
-					'default'     => '{site_title}<br/>Powered by Classic Commerce',
+					'default'     => '{site_title}<br/>Powered by <a href="https://github.com/ClassicPress-research/classic-commerce/">Classic Commerce</a>',
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Email Settings
+ * Classic Commerce Email Settings
  *
  * @package WooCommerce/Admin
  * @version WC-2.1.0
@@ -51,7 +51,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 				array(
 					'title' => __( 'Email notifications', 'woocommerce' ),
-					'desc'  => __( 'Email notifications sent from WooCommerce are listed below. Click on an email to configure it.', 'woocommerce' ),
+					'desc'  => __( 'Email notifications sent from Classic Commerce are listed below. Click on an email to configure it.', 'woocommerce' ),
 					'type'  => 'title',
 					'id'    => 'email_notification_settings',
 				),
@@ -77,7 +77,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 				array(
 					'title'    => __( '"From" name', 'woocommerce' ),
-					'desc'     => __( 'How the sender name appears in outgoing WooCommerce emails.', 'woocommerce' ),
+					'desc'     => __( 'How the sender name appears in outgoing Classic Commerce emails.', 'woocommerce' ),
 					'id'       => 'woocommerce_email_from_name',
 					'type'     => 'text',
 					'css'      => 'min-width:300px;',
@@ -88,7 +88,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 				array(
 					'title'             => __( '"From" address', 'woocommerce' ),
-					'desc'              => __( 'How the sender email appears in outgoing WooCommerce emails.', 'woocommerce' ),
+					'desc'              => __( 'How the sender email appears in outgoing Classic Commerce emails.', 'woocommerce' ),
 					'id'                => 'woocommerce_email_from_address',
 					'type'              => 'email',
 					'custom_attributes' => array(
@@ -109,7 +109,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'title' => __( 'Email template', 'woocommerce' ),
 					'type'  => 'title',
 					/* translators: %s: Nonced email preview link */
-					'desc'  => sprintf( __( 'This section lets you customize the WooCommerce emails. <a href="%s" target="_blank">Click here to preview your email template</a>.', 'woocommerce' ), wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ),
+					'desc'  => sprintf( __( 'This section lets you customize the Classic Commerce emails. <a href="%s" target="_blank">Click here to preview your email template</a>.', 'woocommerce' ), wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ),
 					'id'    => 'email_template_options',
 				),
 
@@ -128,12 +128,12 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				array(
 					'title'       => __( 'Footer text', 'woocommerce' ),
 					/* translators: %s: Available placeholders for use */
-					'desc'        => __( 'The text to appear in the footer of WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title}' ),
+					'desc'        => __( 'The text to appear in the footer of Classic Commerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title}' ),
 					'id'          => 'woocommerce_email_footer_text',
 					'css'         => 'width:300px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',
-					'default'     => '{site_title}<br/>Powered by <a href="https://woocommerce.com/">WooCommerce</a>',
+					'default'     => '{site_title}<br/>Powered by Classic Commerce',
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),
@@ -141,7 +141,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				array(
 					'title'    => __( 'Base color', 'woocommerce' ),
 					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The base color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#96588a</code>' ),
+					'desc'     => sprintf( __( 'The base color for Classic Commerce email templates. Default %s.', 'woocommerce' ), '<code>#96588a</code>' ),
 					'id'       => 'woocommerce_email_base_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
@@ -153,7 +153,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				array(
 					'title'    => __( 'Background color', 'woocommerce' ),
 					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The background color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#f7f7f7</code>' ),
+					'desc'     => sprintf( __( 'The background color for Classic Commerce email templates. Default %s.', 'woocommerce' ), '<code>#f7f7f7</code>' ),
 					'id'       => 'woocommerce_email_background_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change all occurrences of WooCoomerce in the text to Classic Commerce. Change default footer text to "Powered by Classic Commerce". **NB** - this will not show as having changed when testing on existing sites, but it does work correctly on new installations.

### How to test the changes in this Pull Request:

1. Copy class-wc-settings-emails.php to an existing installation.
2. Visit Settings-> Emails page and check text on page.
3. To check the footer it is necessary to start with a clean Classic Commerce installation with the revised file in place before activation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Update email settings page to replace WooCommerce text with Classic Commerce.
