### PR TITLE
Fix admin help screen

### DIFF
--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -50,10 +50,10 @@ class WC_Admin_Help {
 					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
 						__( 'For further assistance with Classic Commerce you can use the <a href="%1$s">ClassicPress community forum</a>.', 'woocommerce' ),
-						' https://forums.classicpress.net/c/support/classic-commerce'
+						'https://forums.classicpress.net/c/support'
 					) . '</p>' .
 					'<p>' . __( 'Before asking for help we recommend using the system status page to identify any problems with your configuration. You should make a copy of this report to add to your support request.', 'woocommerce' ) . '</p>' .
-					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href=" https://forums.classicpress.net/c/support/classic-commerce" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',
+					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href="https://forums.classicpress.net/c/support" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',
 			)
 		);
 

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -43,18 +43,12 @@ class WC_Admin_Help {
 				'content' =>
 					'<h2>' . __( 'Help &amp; Support', 'woocommerce' ) . '</h2>' .
 					'<p>' . sprintf(
-						/* translators: %s: Documentation URL */
-						__( 'Should you need help understanding, using, or extending WooCommerce, <a href="%s">please read our documentation</a>. You will find all kinds of resources including snippets, tutorials and much more.', 'woocommerce' ),
-						'https://docs.woocommerce.com/documentation/plugins/woocommerce/?utm_source=helptab&utm_medium=product&utm_content=docs&utm_campaign=woocommerceplugin'
-					) . '</p>' .
-					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
-						__( 'For further assistance with WooCommerce core you can use the <a href="%1$s">community forum</a>. If you need help with premium extensions sold by WooCommerce, please <a href="%2$s">use our helpdesk</a>.', 'woocommerce' ),
-						'https://wordpress.org/support/plugin/woocommerce',
-						'https://woocommerce.com/my-account/tickets/?utm_source=helptab&utm_medium=product&utm_content=tickets&utm_campaign=woocommerceplugin'
+						__( 'For further assistance with Classic Commerce you can use the <a href="%1$s">ClassicPress community forum</a>.', 'woocommerce' ),
+						'https://forums.classicpress.net/'
 					) . '</p>' .
-					'<p>' . __( 'Before asking for help we recommend checking the system status page to identify any problems with your configuration.', 'woocommerce' ) . '</p>' .
-					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href="https://wordpress.org/support/plugin/woocommerce" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a> <a href="https://woocommerce.com/my-account/tickets/?utm_source=helptab&utm_medium=product&utm_content=tickets&utm_campaign=woocommerceplugin" class="button">' . __( 'WooCommerce helpdesk', 'woocommerce' ) . '</a></p>',
+					'<p>' . __( 'Before asking for help we recommend using the system status page to identify any problems with your configuration. You should make a copy of this report to add to your support request.', 'woocommerce' ) . '</p>' .
+					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href="https://forums.classicpress.net/" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',
 			)
 		);
 
@@ -64,21 +58,9 @@ class WC_Admin_Help {
 				'title'   => __( 'Found a bug?', 'woocommerce' ),
 				'content' =>
 					'<h2>' . __( 'Found a bug?', 'woocommerce' ) . '</h2>' .
-					/* translators: 1: GitHub issues URL 2: GitHub contribution guide URL 3: System status report URL */
-					'<p>' . sprintf( __( 'If you find a bug within WooCommerce core you can create a ticket via <a href="%1$s">Github issues</a>. Ensure you read the <a href="%2$s">contribution guide</a> prior to submitting your report. To help us solve your issue, please be as descriptive as possible and include your <a href="%3$s">system status report</a>.', 'woocommerce' ), 'https://github.com/woocommerce/woocommerce/issues?state=open', 'https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md', admin_url( 'admin.php?page=wc-status' ) ) . '</p>' .
-					'<p><a href="https://github.com/woocommerce/woocommerce/issues?state=open" class="button button-primary">' . __( 'Report a bug', 'woocommerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'woocommerce' ) . '</a></p>',
-
-			)
-		);
-
-		$screen->add_help_tab(
-			array(
-				'id'      => 'woocommerce_education_tab',
-				'title'   => __( 'Education', 'woocommerce' ),
-				'content' =>
-					'<h2>' . __( 'Education', 'woocommerce' ) . '</h2>' .
-					'<p>' . __( 'If you would like to learn about using WooCommerce from an expert, consider a WooCommerce course to further your education.', 'woocommerce' ) . '</p>' .
-					'<p><a href="https://docs.woocommerce.com/document/further-education/?utm_source=helptab&utm_medium=product&utm_content=edupartners&utm_campaign=woocommerceplugin" class="button button-primary">' . __( 'Further education', 'woocommerce' ) . '</a></p>',
+					/* translators: 1: GitHub issues URL 2: System status report URL */
+					'<p>' . sprintf( __( 'If you find a bug within Classic Commerce core you can create a ticket via <a href="%1$s">Github issues</a>. To help us solve your issue, please be as descriptive as possible and include your <a href="%2$s">system status report</a>.', 'woocommerce' ), 'https://github.com/ClassicPress-research/classic-commerce/issues', admin_url( 'admin.php?page=wc-status' ) ) . '</p>' .
+					'<p><a href="https://github.com/ClassicPress-research/classic-commerce/issues" class="button button-primary">' . __( 'Report a bug', 'woocommerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'woocommerce' ) . '</a></p>',
 			)
 		);
 
@@ -90,17 +72,12 @@ class WC_Admin_Help {
 					'<h2>' . __( 'Setup wizard', 'woocommerce' ) . '</h2>' .
 					'<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce' ) . '</p>' .
 					'<p><a href="' . admin_url( 'index.php?page=wc-setup' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce' ) . '</a></p>',
-
 			)
 		);
 
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'woocommerce' ) . '</strong></p>' .
-			'<p><a href="https://woocommerce.com/?utm_source=helptab&utm_medium=product&utm_content=about&utm_campaign=woocommerceplugin" target="_blank">' . __( 'About WooCommerce', 'woocommerce' ) . '</a></p>' .
-			'<p><a href="https://wordpress.org/plugins/woocommerce/" target="_blank">' . __( 'WordPress.org project', 'woocommerce' ) . '</a></p>' .
-			'<p><a href="https://github.com/woocommerce/woocommerce/" target="_blank">' . __( 'Github project', 'woocommerce' ) . '</a></p>' .
-			'<p><a href="https://woocommerce.com/storefront/?utm_source=helptab&utm_medium=product&utm_content=wcthemes&utm_campaign=woocommerceplugin" target="_blank">' . __( 'Official theme', 'woocommerce' ) . '</a></p>' .
-			'<p><a href="https://woocommerce.com/product-category/woocommerce-extensions/?utm_source=helptab&utm_medium=product&utm_content=wcextensions&utm_campaign=woocommerceplugin" target="_blank">' . __( 'Official extensions', 'woocommerce' ) . '</a></p>'
+			'<p><a href="https://github.com/ClassicPress-research/classic-commerce/" target="_blank">' . __( 'Github project', 'woocommerce' ) . '</a></p>'
 		);
 	}
 }

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -43,12 +43,17 @@ class WC_Admin_Help {
 				'content' =>
 					'<h2>' . __( 'Help &amp; Support', 'woocommerce' ) . '</h2>' .
 					'<p>' . sprintf(
+						/* translators: %s: Documentation URL */
+						__( 'Should you need help understanding, using, or extending Classic Commerce, <a href="%s">please refer to the WooCommerce documentation</a>. You will find all kinds of resources including snippets, tutorials and much more.', 'woocommerce' ),
+						'https://docs.woocommerce.com/documentation/plugins/woocommerce/?utm_source=helptab&utm_medium=product&utm_content=docs&utm_campaign=woocommerceplugin'
+					) . '</p>' .
+					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
 						__( 'For further assistance with Classic Commerce you can use the <a href="%1$s">ClassicPress community forum</a>.', 'woocommerce' ),
-						'https://forums.classicpress.net/'
+						'https://forums.classicpress.net/c/support'
 					) . '</p>' .
 					'<p>' . __( 'Before asking for help we recommend using the system status page to identify any problems with your configuration. You should make a copy of this report to add to your support request.', 'woocommerce' ) . '</p>' .
-					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href="https://forums.classicpress.net/" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',
+					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href="https://forums.classicpress.net/c/support" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',
 			)
 		);
 
@@ -77,7 +82,9 @@ class WC_Admin_Help {
 
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'woocommerce' ) . '</strong></p>' .
-			'<p><a href="https://github.com/ClassicPress-research/classic-commerce/" target="_blank">' . __( 'Github project', 'woocommerce' ) . '</a></p>'
+			'<p><a href="https://github.com/ClassicPress-research/classic-commerce/" target="_blank">' . __( 'Github project', 'woocommerce' ) . '</a></p>' .
+			'<p><a href="https://classicpress.net/" target="_blank">' . __( 'About ClassicPress', 'woocommerce' ) . '</a></p>' .
+			'<p><a href="https://woocommerce.com/product-category/woocommerce-extensions/?utm_source=helptab&utm_medium=product&utm_content=wcextensions&utm_campaign=woocommerceplugin" target="_blank">' . __( 'Extensions', 'woocommerce' ) . '</a></p>'
 		);
 	}
 }

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -45,7 +45,7 @@ class WC_Admin_Help {
 					'<p>' . sprintf(
 						/* translators: %s: Documentation URL */
 						__( 'Should you need help understanding, using, or extending Classic Commerce, <a href="%s">please refer to the WooCommerce documentation</a>. You will find all kinds of resources including snippets, tutorials and much more.', 'woocommerce' ),
-						'https://docs.woocommerce.com/documentation/plugins/woocommerce/?utm_source=helptab&utm_medium=product&utm_content=docs&utm_campaign=woocommerceplugin'
+						'https://docs.woocommerce.com/documentation/plugins/woocommerce/'
 					) . '</p>' .
 					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
@@ -84,7 +84,7 @@ class WC_Admin_Help {
 			'<p><strong>' . __( 'For more information:', 'woocommerce' ) . '</strong></p>' .
 			'<p><a href="https://github.com/ClassicPress-research/classic-commerce/" target="_blank">' . __( 'Github project', 'woocommerce' ) . '</a></p>' .
 			'<p><a href="https://classicpress.net/" target="_blank">' . __( 'About ClassicPress', 'woocommerce' ) . '</a></p>' .
-			'<p><a href="https://woocommerce.com/product-category/woocommerce-extensions/?utm_source=helptab&utm_medium=product&utm_content=wcextensions&utm_campaign=woocommerceplugin" target="_blank">' . __( 'Extensions', 'woocommerce' ) . '</a></p>'
+			'<p><a href="https://woocommerce.com/product-category/woocommerce-extensions/" target="_blank">' . __( 'Extensions', 'woocommerce' ) . '</a></p>'
 		);
 	}
 }

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -50,7 +50,7 @@ class WC_Admin_Help {
 					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
 						__( 'For further assistance with Classic Commerce you can use the <a href="%1$s">ClassicPress community forum</a>.', 'woocommerce' ),
-						' https://forums.classicpress.net/c/support/classic-commerce'
+						'https://forums.classicpress.net/c/support/classic-commerce'
 					) . '</p>' .
 					'<p>' . __( 'Before asking for help we recommend using the system status page to identify any problems with your configuration. You should make a copy of this report to add to your support request.', 'woocommerce' ) . '</p>' .
 					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href=" https://forums.classicpress.net/c/support/classic-commerce" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -50,10 +50,10 @@ class WC_Admin_Help {
 					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
 						__( 'For further assistance with Classic Commerce you can use the <a href="%1$s">ClassicPress community forum</a>.', 'woocommerce' ),
-						'https://forums.classicpress.net/c/support'
+						' https://forums.classicpress.net/c/support/classic-commerce'
 					) . '</p>' .
 					'<p>' . __( 'Before asking for help we recommend using the system status page to identify any problems with your configuration. You should make a copy of this report to add to your support request.', 'woocommerce' ) . '</p>' .
-					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href="https://forums.classicpress.net/c/support" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',
+					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'woocommerce' ) . '</a> <a href=" https://forums.classicpress.net/c/support/classic-commerce" class="button">' . __( 'Community forum', 'woocommerce' ) . '</a></p>',
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change the admin drop-down help screen to reflect appropriate Classic Commerce help and support options. Add links to github for more information and for reporting bugs. Add link to ClassicPress forum as a way to get community support (this may change later, but is probably the best option for now).

### How to test the changes in this Pull Request:

1. Copy class-wc-admin-help.php to a test installation.
2. Access admin area and use 'Help' tab at top right of screen to view the help screen.
3. Check all links are working correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Change the admin drop-down help screen to reflect appropriate Classic Commerce help and support options.
