### PR TITLE
Add CP Child Themes as compatible

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -91,14 +91,12 @@ class WC_Admin_Setup_Wizard {
 	protected function is_default_theme() {
 		return wc_is_active_theme(
 			array(
+				'classicpress-twentyseventeen',
+				'classicpress-twentysixteen',
+				'classicpress-twentyfifteen',
 				'twentyseventeen',
 				'twentysixteen',
-				'twentyfifteen',
-				'twentyfourteen',
-				'twentythirteen',
-				'twentyeleven',
-				'twentytwelve',
-				'twentyten',
+				'twentyfifteen'
 			)
 		);
 	}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -96,7 +96,7 @@ class WC_Admin_Setup_Wizard {
 				'classicpress-twentyfifteen',
 				'twentyseventeen',
 				'twentysixteen',
-				'twentyfifteen'
+				'twentyfifteen',
 			)
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Woocommerce supported the default themes in WP by default and found them ready for use. The same themes have been made into child themes. They are still compatible but we need to add them to the list.

Closes #33 .

### How to test the changes in this Pull Request:

1. Install Classic Commerce with any of the default CP child themes.

### Changelog entry
Add support for ClassicPress child themes.