### PR TITLE
Change WC to CC in customizer menu title

### DIFF
--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -33,7 +33,7 @@ class WC_Shop_Customizer {
 			'priority'       => 200,
 			'capability'     => 'manage_woocommerce',
 			'theme_supports' => '',
-			'title'          => __( 'WooCommerce', 'woocommerce' ),
+			'title'          => __( 'Classic Commerce', 'woocommerce' ),
 		) );
 
 		$this->add_store_notice_section( $wp_customize );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change the title in the customizer side menu from Woocommerce to Classic Commerce.

![customizer](https://user-images.githubusercontent.com/46998578/66477812-ba446b80-eae4-11e9-826c-9d8d50fa6049.jpg)

### How to test the changes in this Pull Request:

1. Check out the branch change (specifically class-wc-shop-customizer.php)
2. Visit the test site, open the Appearance section and view side menu

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Change the title in the customizer side menu from Woocommerce to Classic Commerce.
