### PR TITLE
Fix text-domain build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,7 +203,7 @@ module.exports = function( grunt ) {
 		// Check textdomain errors.
 		checktextdomain: {
 			options:{
-				text_domain: 'woocommerce',
+				text_domain: 'classic-commerce',
 				keywords: [
 					'__:1,2d',
 					'_e:1,2d',

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -55,7 +55,7 @@
 	</rule>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="woocommerce" />
+			<property name="text_domain" type="array" value="classic-commerce" />
 		</properties>
 	</rule>
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -6,7 +6,7 @@
  * Version: 0.1.0
  * Author: ClassicPress Research Team
  * Author URI: https://github.com/ClassicPress-research/classic-commerce
- * Text Domain: woocommerce
+ * Text Domain: classic-commerce
  * Domain Path: /i18n/languages/
  *
  * @package WooCommerce


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Following #52, We need to fix the text-domain build process to allow for proper check in the i18n translations.

### How to test the changes in this Pull Request:

1. In console Run `npm install`
2. Run `npm run build`
3. Build should run well with new text-domain 'classic-commerce'

### Changelog entry
- Fix the text-domain build process to allow for proper check in the i18n translations.