### PR TITLE
Archive @since in api to export folders

### DIFF
--- a/includes/api/class-wc-rest-authentication.php
+++ b/includes/api/class-wc-rest-authentication.php
@@ -3,7 +3,7 @@
  * REST API Authentication
  *
  * @package  WooCommerce/API
- * @since    2.6.0
+ * @since    WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /coupons endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-customer-downloads-controller.php
+++ b/includes/api/class-wc-rest-customer-downloads-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /customers/<customer_id>/downloads endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /customers endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,7 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {
 	/**
 	 * Get formatted item data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data $object WC_Data instance.
 	 * @return array
 	 */

--- a/includes/api/class-wc-rest-data-continents-controller.php
+++ b/includes/api/class-wc-rest-data-continents-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /data/continents endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Register routes.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -69,7 +69,7 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Return the list of countries and states for a given continent.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param  string          $continent_code Continent code.
 	 * @param  WP_REST_Request $request        Request data.
 	 * @return array|mixed Response data, ready for insertion into collection data.
@@ -155,7 +155,7 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Return the list of states for all continents.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -175,7 +175,7 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Return the list of locations for a given continent.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -190,7 +190,7 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Prepare the data object for response.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param object          $item Data object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.
@@ -236,7 +236,7 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Get the location schema, conforming to JSON Schema.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @return array
 	 */
 	public function get_item_schema() {

--- a/includes/api/class-wc-rest-data-controller.php
+++ b/includes/api/class-wc-rest-data-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /data endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Data_Controller extends WC_REST_Controller {
 	/**
 	 * Register routes.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -81,7 +81,7 @@ class WC_REST_Data_Controller extends WC_REST_Controller {
 	/**
 	 * Return the list of data resources.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -155,7 +155,7 @@ class WC_REST_Data_Controller extends WC_REST_Controller {
 	/**
 	 * Get the data index schema, conforming to JSON Schema.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @return array
 	 */
 	public function get_item_schema() {

--- a/includes/api/class-wc-rest-data-countries-controller.php
+++ b/includes/api/class-wc-rest-data-countries-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /data/countries endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Register routes.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -103,7 +103,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Return the list of states for all countries.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -123,7 +123,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Return the list of states for a given country.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -138,7 +138,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Prepare the data object for response.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @param object          $item Data object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.
@@ -186,7 +186,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Get the location schema, conforming to JSON Schema.
 	 *
-	 * @since  3.5.0
+	 * @since  WC-3.5.0
 	 * @return array
 	 */
 	public function get_item_schema() {

--- a/includes/api/class-wc-rest-data-currencies-controller.php
+++ b/includes/api/class-wc-rest-data-currencies-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /data/currencies endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-exception.php
+++ b/includes/api/class-wc-rest-exception.php
@@ -5,7 +5,7 @@
  * Extends Exception to provide additional data.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-network-orders-controller.php
+++ b/includes/api/class-wc-rest-network-orders-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders/network endpoint
  *
  * @package WooCommerce/API
- * @since   3.4.0
+ * @since   WC-3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders/<order_id>/notes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders/<order_id>/refunds endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 	/**
 	 * Prepares one object for create or update operation.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Request object.
 	 * @param  bool            $creating If is creating a new object.
 	 * @return WP_Error|WC_Data The prepared item, or WP_Error object on failure.

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders endpoint.
  *
  * @package  WooCommerce/API
- * @since    2.6.0
+ * @since    WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -137,7 +137,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Save an object data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @throws WC_REST_Exception But all errors are validated before returning any data.
 	 * @param  WP_REST_Request $request  Full details about the request.
 	 * @param  bool            $creating If is creating a new object.
@@ -205,7 +205,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Prepare objects query.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */

--- a/includes/api/class-wc-rest-payment-gateways-controller.php
+++ b/includes/api/class-wc-rest-payment-gateways-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /payment_gateways endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-product-attribute-terms-controller.php
+++ b/includes/api/class-wc-rest-product-attribute-terms-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/attributes/<attribute_id>/terms endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-product-attributes-controller.php
+++ b/includes/api/class-wc-rest-product-attributes-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/attributes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/categories endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since  WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to /products/reviews.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since  WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -298,7 +298,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		/**
 		 * Filters arguments, before passing to WP_Comment_Query, when querying reviews via the REST API.
 		 *
-		 * @since 3.5.0
+		 * @since  WC-3.5.0
 		 * @link https://developer.wordpress.org/reference/classes/wp_comment_query/
 		 * @param array           $prepared_args Array of arguments for WP_Comment_Query.
 		 * @param WP_REST_Request $request       The current request.
@@ -445,7 +445,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		 * Returning a WP_Error value from the filter will shortcircuit insertion and allow
 		 * skipping further processing.
 		 *
-		 * @since 3.5.0
+		 * @since  WC-3.5.0
 		 * @param array|WP_Error  $prepared_review The prepared review data for wp_insert_comment().
 		 * @param WP_REST_Request $request          Request used to insert the review.
 		 */
@@ -617,7 +617,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		 *
 		 * Return false to disable trash support for the post.
 		 *
-		 * @since 3.5.0
+		 * @since  WC-3.5.0
 		 * @param bool       $supports_trash Whether the post type support trashing.
 		 * @param WP_Comment $review         The review object being considered for trashing support.
 		 */
@@ -777,7 +777,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		 *
 		 * Allows modification of the review right after it is prepared for the database.
 		 *
-		 * @since 3.5.0
+		 * @since  WC-3.5.0
 		 * @param array           $prepared_review The prepared review data for `wp_insert_comment`.
 		 * @param WP_REST_Request $request         The current request.
 		 */
@@ -1025,7 +1025,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		 * collection parameter to an internal WP_Comment_Query parameter. Use the
 		 * `wc_rest_review_query` filter to set WP_Comment_Query parameters.
 		 *
-		 * @since 3.5.0
+		 * @since  WC-3.5.0
 		 * @param array $params JSON Schema-formatted collection parameters.
 		 */
 		return apply_filters( 'woocommerce_rest_product_review_collection_params', $params );
@@ -1034,7 +1034,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	/**
 	 * Get the reivew, if the ID is valid.
 	 *
-	 * @since 3.5.0
+	 * @since  WC-3.5.0
 	 * @param int $id Supplied ID.
 	 * @return WP_Comment|WP_Error Comment object if ID is valid, WP_Error otherwise.
 	 */
@@ -1065,7 +1065,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	/**
 	 * Prepends internal property prefix to query parameters to match our response fields.
 	 *
-	 * @since 3.5.0
+	 * @since  WC-3.5.0
 	 * @param string $query_param Query parameter.
 	 * @return string
 	 */
@@ -1093,7 +1093,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	/**
 	 * Checks comment_approved to set comment status for single comment output.
 	 *
-	 * @since 3.5.0
+	 * @since  WC-3.5.0
 	 * @param string|int $comment_approved comment status.
 	 * @return string Comment status.
 	 */
@@ -1120,7 +1120,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	/**
 	 * Sets the comment_status of a given review object when creating or updating a review.
 	 *
-	 * @since 3.5.0
+	 * @since  WC-3.5.0
 	 * @param string|int $new_status New review status.
 	 * @param int        $id         Review ID.
 	 * @return bool Whether the status was changed.

--- a/includes/api/class-wc-rest-product-shipping-classes-controller.php
+++ b/includes/api/class-wc-rest-product-shipping-classes-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/shipping_classes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-product-tags-controller.php
+++ b/includes/api/class-wc-rest-product-tags-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/tags endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /products/<product_id>/variations endpoints.
  *
  * @package WooCommerce\API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -750,7 +750,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	/**
 	 * Prepare objects query.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /products endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-report-coupons-totals-controller.php
+++ b/includes/api/class-wc-rest-report-coupons-totals-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /reports/coupons/count endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Report_Coupons_Totals_Controller extends WC_REST_Reports_Controlle
 	/**
 	 * Get reports list.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @return array
 	 */
 	protected function get_reports() {

--- a/includes/api/class-wc-rest-report-customers-totals-controller.php
+++ b/includes/api/class-wc-rest-report-customers-totals-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /reports/customers/count endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Report_Customers_Totals_Controller extends WC_REST_Reports_Control
 	/**
 	 * Get reports list.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @return array
 	 */
 	protected function get_reports() {

--- a/includes/api/class-wc-rest-report-orders-totals-controller.php
+++ b/includes/api/class-wc-rest-report-orders-totals-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /reports/orders/count endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Report_Orders_Totals_Controller extends WC_REST_Reports_Controller
 	/**
 	 * Get reports list.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @return array
 	 */
 	protected function get_reports() {

--- a/includes/api/class-wc-rest-report-products-totals-controller.php
+++ b/includes/api/class-wc-rest-report-products-totals-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /reports/products/count endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Report_Products_Totals_Controller extends WC_REST_Reports_Controll
 	/**
 	 * Get reports list.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @return array
 	 */
 	protected function get_reports() {

--- a/includes/api/class-wc-rest-report-reviews-totals-controller.php
+++ b/includes/api/class-wc-rest-report-reviews-totals-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /reports/reviews/count endpoint.
  *
  * @package WooCommerce/API
- * @since   3.5.0
+ * @since   WC-3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ class WC_REST_Report_Reviews_Totals_Controller extends WC_REST_Reports_Controlle
 	/**
 	 * Get reports list.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @return array
 	 */
 	protected function get_reports() {

--- a/includes/api/class-wc-rest-report-sales-controller.php
+++ b/includes/api/class-wc-rest-report-sales-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the reports/sales endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-report-top-sellers-controller.php
+++ b/includes/api/class-wc-rest-report-top-sellers-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the reports/top_sellers endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-reports-controller.php
+++ b/includes/api/class-wc-rest-reports-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the reports endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,7 @@ class WC_REST_Reports_Controller extends WC_REST_Reports_V2_Controller {
 	/**
 	 * Get reports list.
 	 *
-	 * @since 3.5.0
+	 * @since  WC-3.5.0
 	 * @return array
 	 */
 	protected function get_reports() {

--- a/includes/api/class-wc-rest-setting-options-controller.php
+++ b/includes/api/class-wc-rest-setting-options-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /settings/$group/$setting endpoints.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -127,7 +127,7 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Cont
 	/**
 	 * Returns a list of countries and states for use in the base location setting.
 	 *
-	 * @since  3.0.7
+	 * @since  WC-3.0.7
 	 * @return array Array of states and countries.
 	 */
 	private function get_countries_and_states() {

--- a/includes/api/class-wc-rest-settings-controller.php
+++ b/includes/api/class-wc-rest-settings-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /settings endpoints.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -70,7 +70,7 @@ class WC_REST_Settings_Controller extends WC_REST_Settings_V2_Controller {
 	/**
 	 * Get the groups schema, conforming to JSON Schema.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @return array
 	 */
 	public function get_item_schema() {

--- a/includes/api/class-wc-rest-shipping-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-methods-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping_methods endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-shipping-zone-locations-controller.php
+++ b/includes/api/class-wc-rest-shipping-zone-locations-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping/zones/<id>/locations endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-zone-methods-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping/zones/<id>/methods endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-shipping-zones-controller.php
+++ b/includes/api/class-wc-rest-shipping-zones-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping/zones endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /system_status endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /system_status/tools/* endpoints.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-tax-classes-controller.php
+++ b/includes/api/class-wc-rest-tax-classes-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /taxes/classes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-taxes-controller.php
+++ b/includes/api/class-wc-rest-taxes-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /taxes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/class-wc-rest-webhooks-controller.php
+++ b/includes/api/class-wc-rest-webhooks-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /webhooks endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,7 @@ class WC_REST_Webhooks_Controller extends WC_REST_Webhooks_V2_Controller {
 	/**
 	 * Get the default REST API version.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @return string
 	 */
 	protected function get_default_api_version() {

--- a/includes/api/legacy/class-wc-rest-legacy-coupons-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-coupons-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/class-wc-rest-legacy-products-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-products-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v1/class-wc-api-authentication.php
+++ b/includes/api/legacy/v1/class-wc-api-authentication.php
@@ -5,7 +5,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.1.0
+ * @since    WC-2.1.0
  * @version  2.4.0
  */
 
@@ -189,7 +189,7 @@ class WC_API_Authentication {
 	/**
 	 * Get user by ID
 	 *
-	 * @since  2.4.0
+	 * @since  WC-2.4.0
 	 * @param  int $user_id
 	 * @return WP_User
 	 *

--- a/includes/api/legacy/v1/class-wc-api-coupons.php
+++ b/includes/api/legacy/v1/class-wc-api-coupons.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/class-wc-api-customers.php
+++ b/includes/api/legacy/v1/class-wc-api-customers.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/class-wc-api-json-handler.php
+++ b/includes/api/legacy/v1/class-wc-api-json-handler.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/class-wc-api-orders.php
+++ b/includes/api/legacy/v1/class-wc-api-orders.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/class-wc-api-products.php
+++ b/includes/api/legacy/v1/class-wc-api-products.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     3.0
  */
 

--- a/includes/api/legacy/v1/class-wc-api-reports.php
+++ b/includes/api/legacy/v1/class-wc-api-reports.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/class-wc-api-resource.php
+++ b/includes/api/legacy/v1/class-wc-api-resource.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/class-wc-api-server.php
+++ b/includes/api/legacy/v1/class-wc-api-server.php
@@ -10,7 +10,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/class-wc-api-xml-handler.php
+++ b/includes/api/legacy/v1/class-wc-api-xml-handler.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v1/interface-wc-api-handler.php
+++ b/includes/api/legacy/v1/interface-wc-api-handler.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     2.1
  */
 

--- a/includes/api/legacy/v2/class-wc-api-authentication.php
+++ b/includes/api/legacy/v2/class-wc-api-authentication.php
@@ -5,7 +5,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.1.0
+ * @since    WC-2.1.0
  * @version  2.4.0
  */
 
@@ -188,7 +188,7 @@ class WC_API_Authentication {
 	/**
 	 * Get user by ID
 	 *
-	 * @since  2.4.0
+	 * @since  WC-2.4.0
 	 * @param  int $user_id
 	 * @return WP_User
 	 * @throws Exception

--- a/includes/api/legacy/v2/class-wc-api-coupons.php
+++ b/includes/api/legacy/v2/class-wc-api-coupons.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -444,7 +444,7 @@ class WC_API_Coupons extends WC_API_Resource {
 	/**
 	 * Delete a coupon
 	 *
-	 * @since  2.2
+	 * @since WC-2.2
 	 * @param int $id the coupon ID
 	 * @param bool $force true to permanently delete coupon, false to move to trash
 	 * @return array|WP_Error
@@ -465,7 +465,7 @@ class WC_API_Coupons extends WC_API_Resource {
 	/**
 	 * expiry_date format
 	 *
-	 * @since  2.3.0
+	 * @since  WC-2.3.0
 	 * @param  string $expiry_date
 	 * @param bool $as_timestamp (default: false)
 	 * @return string|int

--- a/includes/api/legacy/v2/class-wc-api-customers.php
+++ b/includes/api/legacy/v2/class-wc-api-customers.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.2
+ * @since    WC-2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -242,7 +242,7 @@ class WC_API_Customers extends WC_API_Resource {
 	/**
 	 * Get customer billing address fields.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @return array
 	 */
 	protected function get_customer_billing_address() {
@@ -266,7 +266,7 @@ class WC_API_Customers extends WC_API_Resource {
 	/**
 	 * Get customer shipping address fields.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @return array
 	 */
 	protected function get_customer_shipping_address() {

--- a/includes/api/legacy/v2/class-wc-api-exception.php
+++ b/includes/api/legacy/v2/class-wc-api-exception.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.2
+ * @since       WC-2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v2/class-wc-api-json-handler.php
+++ b/includes/api/legacy/v2/class-wc-api-json-handler.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     3.0
  */
 
@@ -893,7 +893,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Save product meta
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @param  WC_Product $product
 	 * @param  array $data
 	 * @return WC_Product
@@ -1269,7 +1269,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Save variations
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @param  WC_Product $product
 	 * @param  array $request
 	 *
@@ -1629,7 +1629,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Save product images
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 *
 	 * @param WC_Product $product
 	 * @param array      $images
@@ -1687,7 +1687,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Upload image from URL
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 *
 	 * @param  string $image_url
 	 *
@@ -1972,7 +1972,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Validate attribute data.
 	 *
-	 * @since  2.4.0
+	 * @since  WC-2.4.0
 	 * @param  string $name
 	 * @param  string $slug
 	 * @param  string $type
@@ -2175,7 +2175,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Delete a product attribute
 	 *
-	 * @since  2.4.0
+	 * @since  WC-2.4.0
 	 *
 	 * @param  int $id the product attribute ID
 	 *
@@ -2238,7 +2238,7 @@ class WC_API_Products extends WC_API_Resource {
 	 *
 	 * @deprecated 2.4.0
 	 *
-	 * @since  2.3.0
+	 * @since  WC-2.3.0
 	 *
 	 * @param  int    $sku the product SKU
 	 * @param  string $fields

--- a/includes/api/legacy/v2/class-wc-api-reports.php
+++ b/includes/api/legacy/v2/class-wc-api-reports.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v2/class-wc-api-resource.php
+++ b/includes/api/legacy/v2/class-wc-api-resource.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v2/class-wc-api-server.php
+++ b/includes/api/legacy/v2/class-wc-api-server.php
@@ -10,7 +10,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.1
+ * @since    WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -378,7 +378,7 @@ class WC_API_Server {
 	/**
 	 * urldecode deep.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @param  string|array $value Data to decode with urldecode.
 	 * @return string|array        Decoded data.
 	 */

--- a/includes/api/legacy/v2/class-wc-api-webhooks.php
+++ b/includes/api/legacy/v2/class-wc-api-webhooks.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.2
+ * @since    WC-2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v2/interface-wc-api-handler.php
+++ b/includes/api/legacy/v2/interface-wc-api-handler.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/class-wc-api-authentication.php
+++ b/includes/api/legacy/v3/class-wc-api-authentication.php
@@ -5,7 +5,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.1.0
+ * @since    WC-2.1.0
  * @version  2.4.0
  */
 
@@ -184,7 +184,7 @@ class WC_API_Authentication {
 	/**
 	 * Get user by ID
 	 *
-	 * @since  2.4.0
+	 * @since  WC-2.4.0
 	 *
 	 * @param  int $user_id
 	 *

--- a/includes/api/legacy/v3/class-wc-api-coupons.php
+++ b/includes/api/legacy/v3/class-wc-api-coupons.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -442,7 +442,7 @@ class WC_API_Coupons extends WC_API_Resource {
 	/**
 	 * Delete a coupon
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 *
 	 * @param int $id the coupon ID
 	 * @param bool $force true to permanently delete coupon, false to move to trash
@@ -465,7 +465,7 @@ class WC_API_Coupons extends WC_API_Resource {
 	/**
 	 * expiry_date format
 	 *
-	 * @since  2.3.0
+	 * @since  WC-2.3.0
 	 * @param  string $expiry_date
 	 * @param bool $as_timestamp (default: false)
 	 * @return string|int

--- a/includes/api/legacy/v3/class-wc-api-customers.php
+++ b/includes/api/legacy/v3/class-wc-api-customers.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.2
+ * @since    WC-2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -243,7 +243,7 @@ class WC_API_Customers extends WC_API_Resource {
 	/**
 	 * Get customer billing address fields.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @return array
 	 */
 	protected function get_customer_billing_address() {
@@ -267,7 +267,7 @@ class WC_API_Customers extends WC_API_Resource {
 	/**
 	 * Get customer shipping address fields.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @return array
 	 */
 	protected function get_customer_shipping_address() {

--- a/includes/api/legacy/v3/class-wc-api-exception.php
+++ b/includes/api/legacy/v3/class-wc-api-exception.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.2
+ * @since       WC-2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/class-wc-api-json-handler.php
+++ b/includes/api/legacy/v3/class-wc-api-json-handler.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  * @version     3.0
  */
 
@@ -694,7 +694,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Create a new product category.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  array          $data Posted data
 	 * @return array|WP_Error       Product category if succeed, otherwise WP_Error
 	 *                              will be returned
@@ -770,7 +770,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Edit a product category.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  int            $id   Product category term ID
 	 * @param  array          $data Posted data
 	 * @return array|WP_Error       Product category if succeed, otherwise WP_Error
@@ -841,7 +841,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Delete a product category.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  int            $id Product category term ID
 	 * @return array|WP_Error     Success message if succeed, otherwise WP_Error
 	 *                            will be returned
@@ -877,7 +877,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Get a listing of product tags.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 *
 	 * @param  string|null $fields Fields to limit response to
 	 *
@@ -907,7 +907,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Get the product tag for the given ID.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 *
 	 * @param  string $id          Product tag term ID
 	 * @param  string|null $fields Fields to limit response to
@@ -953,7 +953,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Create a new product tag.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  array          $data Posted data
 	 * @return array|WP_Error       Product tag if succeed, otherwise WP_Error
 	 *                              will be returned
@@ -997,7 +997,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Edit a product tag.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  int            $id   Product tag term ID
 	 * @param  array          $data Posted data
 	 * @return array|WP_Error       Product tag if succeed, otherwise WP_Error
@@ -1040,7 +1040,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Delete a product tag.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  int            $id Product tag term ID
 	 * @return array|WP_Error     Success message if succeed, otherwise WP_Error
 	 *                            will be returned
@@ -1300,7 +1300,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Get grouped products data
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  WC_Product $product
 	 *
 	 * @return array
@@ -1383,7 +1383,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Save product meta.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @param  WC_Product $product
 	 * @param  array $data
 	 * @return WC_Product
@@ -1763,7 +1763,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Save variations.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 *
 	 * @param  WC_Product $product
 	 * @param  array $request
@@ -2133,7 +2133,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Save product images.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @param  WC_Product $product
 	 * @param  array $images
 	 * @throws WC_API_Exception
@@ -2311,7 +2311,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Sets uploaded category image as attachment and returns the attachment ID.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  integer $upload Upload information from wp_upload_bits
 	 * @return int             Attachment ID
 	 */
@@ -2322,7 +2322,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Set uploaded image as attachment.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  array $upload Upload information from wp_upload_bits
 	 * @param  int   $id     Post ID. Default to 0.
 	 * @return int           Attachment ID
@@ -2530,7 +2530,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Validate attribute data.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  string $name
 	 * @param  string $slug
 	 * @param  string $type
@@ -2735,7 +2735,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Delete a product attribute.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 *
 	 * @param  int $id the product attribute ID.
 	 *
@@ -3033,7 +3033,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Delete a product attribute term.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 *
 	 * @param int $attribute_id Attribute ID.
 	 * @param int $id the product attribute ID.
@@ -3180,7 +3180,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Get a listing of product shipping classes.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  string|null    $fields Fields to limit response to
 	 * @return array|WP_Error         List of product shipping classes if succeed,
 	 *                                otherwise WP_Error will be returned
@@ -3209,7 +3209,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Get the product shipping class for the given ID.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  string         $id     Product shipping class term ID
 	 * @param  string|null    $fields Fields to limit response to
 	 * @return array|WP_Error         Product shipping class if succeed, otherwise
@@ -3253,7 +3253,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Create a new product shipping class.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  array          $data Posted data
 	 * @return array|WP_Error       Product shipping class if succeed, otherwise
 	 *                              WP_Error will be returned
@@ -3310,7 +3310,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Edit a product shipping class.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  int            $id   Product shipping class term ID
 	 * @param  array          $data Posted data
 	 * @return array|WP_Error       Product shipping class if succeed, otherwise
@@ -3355,7 +3355,7 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Delete a product shipping class.
 	 *
-	 * @since  2.5.0
+	 * @since  WC-2.5.0
 	 * @param  int            $id Product shipping class term ID
 	 * @return array|WP_Error     Success message if succeed, otherwise WP_Error
 	 *                            will be returned

--- a/includes/api/legacy/v3/class-wc-api-reports.php
+++ b/includes/api/legacy/v3/class-wc-api-reports.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/class-wc-api-resource.php
+++ b/includes/api/legacy/v3/class-wc-api-resource.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/class-wc-api-server.php
+++ b/includes/api/legacy/v3/class-wc-api-server.php
@@ -10,7 +10,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.1
+ * @since    WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -378,7 +378,7 @@ class WC_API_Server {
 	/**
 	 * urldecode deep.
 	 *
-	 * @since  2.2
+	 * @since  WC-2.2
 	 * @param  string|array $value Data to decode with urldecode.
 	 *
 	 * @return string|array        Decoded data.

--- a/includes/api/legacy/v3/class-wc-api-taxes.php
+++ b/includes/api/legacy/v3/class-wc-api-taxes.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.5.0
+ * @since    WC-2.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/class-wc-api-webhooks.php
+++ b/includes/api/legacy/v3/class-wc-api-webhooks.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.2
+ * @since    WC-2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/legacy/v3/interface-wc-api-handler.php
+++ b/includes/api/legacy/v3/interface-wc-api-handler.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    API
  * @package     WooCommerce/API
- * @since       2.1
+ * @since       WC-2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-coupons-controller.php
+++ b/includes/api/v1/class-wc-rest-coupons-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-customer-downloads-controller.php
+++ b/includes/api/v1/class-wc-rest-customer-downloads-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-customers-controller.php
+++ b/includes/api/v1/class-wc-rest-customers-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-order-notes-controller.php
+++ b/includes/api/v1/class-wc-rest-order-notes-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/v1/class-wc-rest-order-refunds-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    2.6.0
+ * @since    WC-2.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-product-attribute-terms-controller.php
+++ b/includes/api/v1/class-wc-rest-product-attribute-terms-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-product-attributes-controller.php
+++ b/includes/api/v1/class-wc-rest-product-attributes-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/v1/class-wc-rest-product-reviews-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-product-shipping-classes-controller.php
+++ b/includes/api/v1/class-wc-rest-product-shipping-classes-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-product-tags-controller.php
+++ b/includes/api/v1/class-wc-rest-product-tags-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-report-sales-controller.php
+++ b/includes/api/v1/class-wc-rest-report-sales-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-report-top-sellers-controller.php
+++ b/includes/api/v1/class-wc-rest-report-top-sellers-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-reports-controller.php
+++ b/includes/api/v1/class-wc-rest-reports-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -68,7 +68,7 @@ class WC_REST_Reports_V1_Controller extends WC_REST_Controller {
 	/**
 	 * Get reports list.
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @return array
 	 */
 	protected function get_reports() {

--- a/includes/api/v1/class-wc-rest-tax-classes-controller.php
+++ b/includes/api/v1/class-wc-rest-tax-classes-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-taxes-controller.php
+++ b/includes/api/v1/class-wc-rest-taxes-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-webhook-deliveries-controller.php
+++ b/includes/api/v1/class-wc-rest-webhook-deliveries-controller.php
@@ -7,7 +7,7 @@
  * @author   WooThemes
  * @category API
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/api/v1/class-wc-rest-webhooks-controller.php
+++ b/includes/api/v1/class-wc-rest-webhooks-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /webhooks endpoint.
  *
  * @package  WooCommerce/API
- * @since    3.0.0
+ * @since    WC-3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -210,7 +210,7 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 	/**
 	 * Get the default REST API version.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @return string
 	 */
 	protected function get_default_api_version() {

--- a/includes/api/v2/class-wc-rest-coupons-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-coupons-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /coupons endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -123,7 +123,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_Legacy_Coupons_Controller {
 	/**
 	 * Get object.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $id Object ID.
 	 * @return WC_Data
 	 */
@@ -134,7 +134,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_Legacy_Coupons_Controller {
 	/**
 	 * Get formatted item data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data $object WC_Data instance.
 	 * @return array
 	 */
@@ -196,7 +196,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_Legacy_Coupons_Controller {
 	/**
 	 * Prepare a single coupon output for response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data         $object  Object data.
 	 * @param  WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
@@ -225,7 +225,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_Legacy_Coupons_Controller {
 	/**
 	 * Prepare objects query.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */

--- a/includes/api/v2/class-wc-rest-customer-downloads-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-customer-downloads-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /customers/<customer_id>/downloads endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-customers-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-customers-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /customers endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,7 @@ class WC_REST_Customers_V2_Controller extends WC_REST_Customers_V1_Controller {
 	/**
 	 * Get formatted item data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data $object WC_Data instance.
 	 * @return array
 	 */

--- a/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders/network endpoint
  *
  * @package  WooCommerce/API
- * @since    3.4.0
+ * @since    WC-3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-order-notes-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-order-notes-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders/<order_id>/notes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-order-refunds-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-order-refunds-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders/<order_id>/refunds endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -121,7 +121,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Get object.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $id Object ID.
 	 * @return WC_Data
 	 */
@@ -132,7 +132,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Get formatted item data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data $object WC_Data instance.
 	 * @return array
 	 */
@@ -175,7 +175,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Prepare a single order output for response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 *
 	 * @param  WC_Data         $object  Object data.
 	 * @param  WP_REST_Request $request Request object.
@@ -245,7 +245,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Prepare objects query.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */
@@ -261,7 +261,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Prepares one object for create or update operation.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Request object.
 	 * @param  bool            $creating If is creating a new object.
 	 * @return WP_Error|WC_Data The prepared item, or WP_Error object on failure.
@@ -319,7 +319,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	/**
 	 * Save an object data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request  Full details about the request.
 	 * @param  bool            $creating If is creating a new object.
 	 * @return WC_Data|WP_Error

--- a/includes/api/v2/class-wc-rest-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-orders-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /orders endpoint.
  *
  * @package  WooCommerce/API
- * @since    2.6.0
+ * @since    WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -129,7 +129,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 	/**
 	 * Get object. Return false if object is not of required type.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $id Object ID.
 	 * @return WC_Data|bool
 	 */
@@ -197,7 +197,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 	/**
 	 * Get formatted item data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data $object WC_Data instance.
 	 * @return array
 	 */
@@ -285,7 +285,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 	/**
 	 * Prepare a single order output for response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data         $object  Object data.
 	 * @param  WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
@@ -348,7 +348,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 	/**
 	 * Prepare objects query.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */
@@ -504,7 +504,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 	/**
 	 * Save an object data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @throws WC_REST_Exception But all errors are validated before returning any data.
 	 * @param  WP_REST_Request $request  Full details about the request.
 	 * @param  bool            $creating If is creating a new object.

--- a/includes/api/v2/class-wc-rest-payment-gateways-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-payment-gateways-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /payment_gateways endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-product-attribute-terms-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-attribute-terms-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/attributes/<attribute_id>/terms endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-product-attributes-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-attributes-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/attributes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/categories endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-product-reviews-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-reviews-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to /products/<product_id>/reviews.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -112,7 +112,7 @@ class WC_REST_Product_Reviews_V2_Controller extends WC_REST_Product_Reviews_V1_C
 	/**
 	 * Bulk create, update and delete items.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return array Of WP_Error or WP_REST_Response.
 	 */

--- a/includes/api/v2/class-wc-rest-product-shipping-classes-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-shipping-classes-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/shipping_classes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-product-tags-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-tags-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the products/tags endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-product-variations-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-variations-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /products/<product_id>/variations endpoints.
  *
  * @package WooCommerce\API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -141,7 +141,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	/**
 	 * Get object.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $id Object ID.
 	 * @return WC_Data
 	 */
@@ -173,7 +173,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	/**
 	 * Prepare a single variation output for response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data         $object  Object data.
 	 * @param  WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
@@ -247,7 +247,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	/**
 	 * Prepare objects query.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */
@@ -586,7 +586,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	/**
 	 * Bulk create, update and delete items.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return array Of WP_Error or WP_REST_Response.
 	 */

--- a/includes/api/v2/class-wc-rest-products-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-products-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /products endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -133,7 +133,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Get object.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $id Object ID.
 	 * @return WC_Data
 	 */
@@ -144,7 +144,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Prepare a single product output for response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data         $object  Object data.
 	 * @param  WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
@@ -184,7 +184,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Prepare objects query.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */
@@ -435,7 +435,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Get product attribute taxonomy name.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  string     $slug    Taxonomy name.
 	 * @param  WC_Product $product Product data.
 	 * @return string

--- a/includes/api/v2/class-wc-rest-report-sales-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-report-sales-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the reports/sales endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-report-top-sellers-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-report-top-sellers-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the reports/top_sellers endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-reports-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-reports-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the reports endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-setting-options-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-setting-options-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /settings/$group/$setting endpoints.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -104,7 +104,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Return a single setting.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -123,7 +123,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Return all settings in a group.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -150,7 +150,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Get all settings in a group.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param string $group_id Group ID.
 	 * @return array|WP_Error
 	 */
@@ -196,7 +196,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Returns a list of countries and states for use in the base location setting.
 	 *
-	 * @since  3.0.7
+	 * @since  WC-3.0.7
 	 * @return array Array of states and countries.
 	 */
 	private function get_countries_and_states() {
@@ -224,7 +224,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Get setting data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param string $group_id Group ID.
 	 * @param string $setting_id Setting ID.
 	 * @return stdClass|WP_Error
@@ -258,7 +258,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Bulk create, update and delete items.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return array Of WP_Error or WP_REST_Response.
 	 */
@@ -285,7 +285,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Update a single setting in a group.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -327,7 +327,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Prepare a single setting object for response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param object          $item Setting object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.
@@ -345,7 +345,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Prepare links for the request.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param string $setting_id Setting ID.
 	 * @param string $group_id Group ID.
 	 * @return array Links for the given setting.
@@ -367,7 +367,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Makes sure the current user has access to READ the settings APIs.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
 	 */
@@ -382,7 +382,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Makes sure the current user has access to WRITE the settings APIs.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
 	 */
@@ -442,7 +442,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Callback for allowed keys for each setting response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  string $key Key to check.
 	 * @return boolean
 	 */
@@ -466,7 +466,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Boolean for if a setting type is a valid supported setting type.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  string $type Type.
 	 * @return bool
 	 */

--- a/includes/api/v2/class-wc-rest-settings-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-settings-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /settings endpoints.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -53,7 +53,7 @@ class WC_REST_Settings_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Get all settings groups items.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -108,7 +108,7 @@ class WC_REST_Settings_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Prepare a report sales object for serialization.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param array           $item Group object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.
@@ -143,7 +143,7 @@ class WC_REST_Settings_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Callback for allowed keys for each group response.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  string $key Key to check.
 	 * @return boolean
 	 */
@@ -154,7 +154,7 @@ class WC_REST_Settings_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Returns default settings for groups. null means the field is required.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @return array
 	 */
 	protected function group_defaults() {
@@ -170,7 +170,7 @@ class WC_REST_Settings_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Makes sure the current user has access to READ the settings APIs.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|boolean
 	 */
@@ -185,7 +185,7 @@ class WC_REST_Settings_V2_Controller extends WC_REST_Controller {
 	/**
 	 * Get the groups schema, conforming to JSON Schema.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @return array
 	 */
 	public function get_item_schema() {

--- a/includes/api/v2/class-wc-rest-shipping-methods-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-shipping-methods-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping_methods endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-shipping-zone-locations-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-shipping-zone-locations-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping/zones/<id>/locations endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-shipping-zone-methods-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-shipping-zone-methods-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping/zones/<id>/methods endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-shipping-zones-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-shipping-zones-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /shipping/zones endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /system_status/tools/* endpoints.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /system_status endpoint.
  *
  * @package WooCommerce/API
- * @since   3.0.0
+ * @since   WC-3.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-tax-classes-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-tax-classes-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /taxes/classes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-taxes-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-taxes-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /taxes endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-webhook-deliveries-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-webhook-deliveries-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /webhooks/<webhook_id>/deliveries endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/api/v2/class-wc-rest-webhooks-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-webhooks-v2-controller.php
@@ -5,7 +5,7 @@
  * Handles requests to the /webhooks endpoint.
  *
  * @package WooCommerce/API
- * @since   2.6.0
+ * @since   WC-2.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -76,7 +76,7 @@ class WC_REST_Webhooks_V2_Controller extends WC_REST_Webhooks_V1_Controller {
 	/**
 	 * Get the default REST API version.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @return string
 	 */
 	protected function get_default_api_version() {

--- a/includes/data-stores/class-wc-customer-download-data-store.php
+++ b/includes/data-stores/class-wc-customer-download-data-store.php
@@ -228,7 +228,7 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 	/**
 	 * Method to delete a download permission from the database by user ID.
 	 *
-	 * @since 3.4.0
+	 * @since WC-3.4.0
 	 * @param int $id user ID of the downloads that will be deleted.
 	 * @return bool True if deleted rows.
 	 */
@@ -246,7 +246,7 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 	/**
 	 * Method to delete a download permission from the database by user email.
 	 *
-	 * @since 3.4.0
+	 * @since WC-3.4.0
 	 * @param string $email email of the downloads that will be deleted.
 	 * @return bool True if deleted rows.
 	 */

--- a/includes/data-stores/class-wc-customer-download-log-data-store.php
+++ b/includes/data-stores/class-wc-customer-download-log-data-store.php
@@ -226,7 +226,7 @@ class WC_Customer_Download_Log_Data_Store implements WC_Customer_Download_Log_Da
 	/**
 	 * Method to delete download logs for a given permission ID.
 	 *
-	 * @since 3.4.0
+	 * @since WC-3.4.0
 	 * @param int $id download_id of the downloads that will be deleted.
 	 */
 	public function delete_by_permission_id( $id ) {

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -45,7 +45,7 @@ class WC_Data_Store_WP {
 	/**
 	 * Get and store terms from a taxonomy.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data|integer $object WC_Data object or object ID.
 	 * @param  string          $taxonomy Taxonomy name e.g. product_cat.
 	 * @return array of terms
@@ -66,7 +66,7 @@ class WC_Data_Store_WP {
 	/**
 	 * Returns an array of meta for an object.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data $object WC_Data object.
 	 * @return array
 	 */
@@ -93,7 +93,7 @@ class WC_Data_Store_WP {
 	/**
 	 * Deletes meta based on meta ID.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing at least ->id).
 	 */
@@ -104,7 +104,7 @@ class WC_Data_Store_WP {
 	/**
 	 * Add new piece of meta.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->key and ->value).
 	 * @return int meta ID
@@ -116,7 +116,7 @@ class WC_Data_Store_WP {
 	/**
 	 * Update meta.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->id, ->key and ->value).
 	 */
@@ -127,7 +127,7 @@ class WC_Data_Store_WP {
 	/**
 	 * Table structure is slightly different between meta types, this function will return what we need to know.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @return array Array elements: table, object_id_field, meta_id_field
 	 */
 	protected function get_db_info() {

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -761,7 +761,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	/**
 	 * Return the order type of a given item which belongs to WC_Order.
 	 *
-	 * @since  3.2.0
+	 * @since  WC-3.2.0
 	 * @param  WC_Order $order Order Object.
 	 * @param  int      $order_item_id Order item id.
 	 * @return string Order Item type

--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -19,7 +19,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	/**
 	 * Add an order item to an order.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int   $order_id Order ID.
 	 * @param  array $item order_item_name and order_item_type.
 	 * @return int Order Item ID
@@ -46,7 +46,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	/**
 	 * Update an order item.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int   $item_id Item ID.
 	 * @param  array $item order_item_name or order_item_type.
 	 * @return boolean
@@ -59,7 +59,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	/**
 	 * Delete an order item.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $item_id Item ID.
 	 */
 	public function delete_order_item( $item_id ) {
@@ -71,7 +71,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	/**
 	 * Update term meta.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int    $item_id Item ID.
 	 * @param  string $meta_key Meta key.
 	 * @param  mixed  $meta_value Meta value.
@@ -85,7 +85,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	/**
 	 * Add term meta.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int    $item_id Item ID.
 	 * @param  string $meta_key Meta key.
 	 * @param  mixed  $meta_value Meta value.
@@ -99,7 +99,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	/**
 	 * Delete term meta.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int    $item_id Item ID.
 	 * @param  string $meta_key Meta key.
 	 * @param  string $meta_value (default: '').
@@ -113,7 +113,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	/**
 	 * Get term meta.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int    $item_id Item ID.
 	 * @param  string $key Meta key.
 	 * @param  bool   $single (default: true).

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1041,7 +1041,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * Find a matching (enabled) variation within a variable product.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Product $product Variable product.
 	 * @param  array      $match_attributes Array of attributes we want to try to match.
 	 * @return int Matching variation ID or 0.
@@ -1218,7 +1218,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 *
 	 * Uses queries rather than update_post_meta so we can do this in one query (to avoid stock issues).
 	 *
-	 * @since  3.0.0 this supports set, increase and decrease.
+	 * @since  WC-3.0.0 this supports set, increase and decrease.
 	 * @param  int      $product_id_with_stock Product ID.
 	 * @param  int|null $stock_quantity Stock quantity.
 	 * @param  string   $operation Set, increase and decrease.
@@ -1263,7 +1263,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 *
 	 * Uses queries rather than update_post_meta so we can do this in one query for performance.
 	 *
-	 * @since  3.0.0 this supports set, increase and decrease.
+	 * @since  WC-3.0.0 this supports set, increase and decrease.
 	 * @param  int      $product_id Product ID.
 	 * @param  int|null $quantity Quantity.
 	 * @param  string   $operation set, increase and decrease.

--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -44,7 +44,7 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	/**
 	 * Handle updated meta props after updating meta data.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Product $product Product object.
 	 */
 	protected function handle_updated_props( &$product ) {

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -230,7 +230,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * Can be filtered by plugins which modify costs, but otherwise will include the raw meta costs unlike get_price() which runs costs through the woocommerce_get_price filter.
 	 * This is to ensure modified prices are not cached, unless intended.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Product $product Product object.
 	 * @param  bool       $for_display If true, prices will be adapted for display based on the `woocommerce_tax_display_shop` setting (including or excluding taxes).
 	 * @return array of prices
@@ -353,7 +353,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * Create unique cache key based on the tax location (affects displayed/cached prices), product version and active price filters.
 	 * DEVELOPERS should filter this hash if offering conditional pricing to keep it unique.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Product $product Product object.
 	 * @param  bool       $for_display If taxes should be calculated or not.
 	 * @return string

--- a/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -103,7 +103,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	/**
 	 * Deletes a shipping zone from the database.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  WC_Shipping_Zone $zone Shipping zone object.
 	 * @param  array            $args Array of args to pass to the delete method.
 	 * @return void
@@ -126,7 +126,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	/**
 	 * Get a list of shipping methods for a specific zone.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int  $zone_id      Zone ID.
 	 * @param  bool $enabled_only True to request enabled methods only.
 	 * @return array               Array of objects containing method_id, method_order, instance_id, is_enabled
@@ -146,7 +146,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	/**
 	 * Get count of methods for a zone.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $zone_id Zone ID.
 	 * @return int Method Count
 	 */
@@ -158,7 +158,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	/**
 	 * Add a shipping method to a zone.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int    $zone_id Zone ID.
 	 * @param  string $type    Method Type/ID.
 	 * @param  int    $order   Method Order.
@@ -197,7 +197,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	/**
 	 * Get a shipping zone method instance.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $instance_id Instance ID.
 	 * @return object
 	 */
@@ -209,7 +209,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	/**
 	 * Find a matching zone ID for a given package.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  object $package Package information.
 	 * @return int
 	 */
@@ -265,7 +265,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	/**
 	 * Return a zone ID from an instance ID.
 	 *
-	 * @since  3.0.0
+	 * @since  WC-3.0.0
 	 * @param  int $id Instnace ID.
 	 * @return int
 	 */

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -18,7 +18,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	/**
 	 * Create a new webhook in the database.
 	 *
-	 * @since 3.3.0
+	 * @since WC-3.3.0
 	 * @param WC_Webhook $webhook Webhook instance.
 	 */
 	public function create( &$webhook ) {
@@ -67,7 +67,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	/**
 	 * Read a webhook from the database.
 	 *
-	 * @since  3.3.0
+	 * @since  WC-3.3.0
 	 * @param  WC_Webhook $webhook Webhook instance.
 	 * @throws Exception When webhook is invalid.
 	 */
@@ -110,7 +110,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	/**
 	 * Update a webhook.
 	 *
-	 * @since 3.3.0
+	 * @since WC-3.3.0
 	 * @param WC_Webhook $webhook Webhook instance.
 	 */
 	public function update( &$webhook ) {
@@ -165,7 +165,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	/**
 	 * Remove a webhook from the database.
 	 *
-	 * @since 3.3.0
+	 * @since WC-3.3.0
 	 * @param WC_Webhook $webhook      Webhook instance.
 	 * @param bool       $force_delete Skip trash bin forcing to delete.
 	 */
@@ -188,7 +188,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	/**
 	 * Get API version number.
 	 *
-	 * @since  3.3.0
+	 * @since  WC-3.3.0
 	 * @param  string $api_version REST API version.
 	 * @return int
 	 */
@@ -199,7 +199,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	/**
 	 * Get all webhooks IDs.
 	 *
-	 * @since  3.3.0
+	 * @since  WC-3.3.0
 	 * @return int[]
 	 */
 	public function get_webhooks_ids() {

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -63,7 +63,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -86,7 +86,7 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		 * Get email subject.
 		 *
 		 * @param bool $paid Whether the order has been paid or not.
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject( $paid = false ) {
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		 * Get email heading.
 		 *
 		 * @param bool $paid Whether the order has been paid or not.
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading( $paid = false ) {

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -61,7 +61,7 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -63,7 +63,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -65,7 +65,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		 * Get email subject.
 		 *
 		 * @param bool $partial Whether it is a partial refund or a full refund.
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject( $partial = false ) {
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		 * Get email heading.
 		 *
 		 * @param bool $partial Whether it is a partial refund or a full refund.
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading( $partial = false ) {

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -85,7 +85,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -62,7 +62,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		/**
 		 * Get email subject.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_subject() {
@@ -69,7 +69,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @since  3.1.0
+		 * @since  WC-3.1.0
 		 * @return string
 		 */
 		public function get_default_heading() {

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -328,7 +328,7 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Get email subject.
 	 *
-	 * @since  3.1.0
+	 * @since  WC-3.1.0
 	 * @return string
 	 */
 	public function get_default_subject() {
@@ -338,7 +338,7 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Get email heading.
 	 *
-	 * @since  3.1.0
+	 * @since  WC-3.1.0
 	 * @return string
 	 */
 	public function get_default_heading() {

--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -51,7 +51,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Get the file contents.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return string
 	 */
 	public function get_file() {
@@ -68,7 +68,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Serve the file and remove once sent to the client.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 */
 	public function export() {
 		$this->send_headers();
@@ -80,7 +80,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Generate the CSV file.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 */
 	public function generate_file() {
 		if ( 1 === $this->get_page() ) {
@@ -93,7 +93,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Write data to the file.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param string $data Data.
 	 */
 	protected function write_csv_data( $data ) {
@@ -111,7 +111,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Get page.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return int
 	 */
 	public function get_page() {
@@ -121,7 +121,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Set page.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param int $page Page Nr.
 	 */
 	public function set_page( $page ) {
@@ -131,7 +131,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Get count of records exported.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return int
 	 */
 	public function get_total_exported() {
@@ -141,7 +141,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	/**
 	 * Get total % complete.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return int
 	 */
 	public function get_percent_complete() {

--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -79,7 +79,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Return an array of supported column names and ids.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return array
 	 */
 	public function get_column_names() {
@@ -89,7 +89,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Set column names.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param array $column_names Column names array.
 	 */
 	public function set_column_names( $column_names ) {
@@ -103,7 +103,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Return an array of columns to export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return array
 	 */
 	public function get_columns_to_export() {
@@ -113,7 +113,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Set columns to export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param array $columns Columns array.
 	 */
 	public function set_columns_to_export( $columns ) {
@@ -123,7 +123,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * See if a column is to be exported or not.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param  string $column_id ID of the column being exported.
 	 * @return boolean
 	 */
@@ -145,7 +145,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Return default columns.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return array
 	 */
 	public function get_default_column_names() {
@@ -155,7 +155,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Do the export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 */
 	public function export() {
 		$this->prepare_data_to_export();
@@ -167,7 +167,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Set the export headers.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 */
 	public function send_headers() {
 		if ( function_exists( 'gc_enable' ) ) {
@@ -209,7 +209,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Set the export content.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param string $csv_data All CSV content.
 	 */
 	public function send_content( $csv_data ) {
@@ -219,7 +219,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Get CSV data for this export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return string
 	 */
 	protected function get_csv_data() {
@@ -229,7 +229,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Export column headers in CSV format.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return string
 	 */
 	protected function export_column_headers() {
@@ -253,7 +253,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Get data that will be exported.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return array
 	 */
 	protected function get_data_to_export() {
@@ -263,7 +263,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Export rows in CSV format.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return string
 	 */
 	protected function export_rows() {
@@ -279,7 +279,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Export rows to an array ready for the CSV.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param array    $row_data Data to export.
 	 * @param string   $key Column being exported.
 	 * @param resource $buffer Output buffer.
@@ -307,7 +307,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Get batch limit.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return int
 	 */
 	public function get_limit() {
@@ -317,7 +317,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Set batch limit.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param int $limit Limit to export.
 	 */
 	public function set_limit( $limit ) {
@@ -327,7 +327,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Get count of records exported.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return int
 	 */
 	public function get_total_exported() {
@@ -346,7 +346,7 @@ abstract class WC_CSV_Exporter {
 	 * @see http://www.contextis.com/resources/blog/comma-separated-vulnerabilities/
 	 * @see https://hackerone.com/reports/72785
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param string $data CSV field to escape.
 	 * @return string
 	 */
@@ -363,7 +363,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Format and escape data ready for the CSV file.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param  string $data Data to format.
 	 * @return string
 	 */
@@ -391,7 +391,7 @@ abstract class WC_CSV_Exporter {
 	/**
 	 * Format term ids to names.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param  array  $term_ids Term IDs to format.
 	 * @param  string $taxonomy Taxonomy name.
 	 * @return string
@@ -442,7 +442,7 @@ abstract class WC_CSV_Exporter {
 	 * Implode CSV cell values using commas by default, and wrapping values
 	 * which contain the separator.
 	 *
-	 * @since  3.2.0
+	 * @since  WC-3.2.0
 	 * @param  array $values Values to implode.
 	 * @return string
 	 */
@@ -467,7 +467,7 @@ abstract class WC_CSV_Exporter {
 	 * @see https://bugs.php.net/bug.php?id=43225
 	 * @see https://bugs.php.net/bug.php?id=50686
 	 * @see https://github.com/woocommerce/woocommerce/issues/19514
-	 * @since 3.4.0
+	 * @since WC-3.4.0
 	 * @param resource $buffer Resource we are writing to.
 	 * @param array    $export_row Row to export.
 	 */

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -61,7 +61,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Should meta be exported?
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param bool $enable_meta_export Should meta be exported.
 	 */
 	public function enable_meta_export( $enable_meta_export ) {
@@ -71,7 +71,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Product types to export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param array $product_types_to_export List of types to export.
 	 */
 	public function set_product_types_to_export( $product_types_to_export ) {
@@ -81,7 +81,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Product category to export
 	 *
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @param string $product_category_to_export Product category slug to export, empty string exports all.
 	 * @return void
 	 */
@@ -92,7 +92,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Return an array of columns to export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @return array
 	 */
 	public function get_default_column_names() {
@@ -146,7 +146,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Prepare data for export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 */
 	public function prepare_data_to_export() {
 		$args = array(
@@ -243,7 +243,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get published value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return int
 	 */
@@ -282,7 +282,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get product_cat value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -294,7 +294,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get product_tag value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -306,7 +306,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get product_shipping_class value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -318,7 +318,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get images value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -340,7 +340,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Prepare linked products for export.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param int[] $linked_products Array of linked product ids.
 	 * @return string
 	 */
@@ -361,7 +361,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get cross_sell_ids value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -372,7 +372,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get upsell_ids value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -383,7 +383,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get parent_id value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -402,7 +402,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get grouped_products value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -427,7 +427,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get download_limit value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -438,7 +438,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get download_expiry value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -449,7 +449,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get stock value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -469,7 +469,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get stock status value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -486,7 +486,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get backorders.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -505,7 +505,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * Get low stock amount value.
 	 *
 	 * @param WC_Product $product Product being exported.
-	 * @since 3.5.0
+	 * @since WC-3.5.0
 	 * @return int|string Empty string if value not set
 	 */
 	protected function get_column_value_low_stock_amount( $product ) {
@@ -515,7 +515,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get type value.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @return string
 	 */
@@ -537,7 +537,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Export downloads.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @param array      $row     Row being exported.
 	 */
@@ -563,7 +563,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Export attributes data.
 	 *
-	 * @since 3.1.0
+	 * @since  WC-3.1.0
 	 * @param  WC_Product $product Product being exported.
 	 * @param  array      $row     Row being exported.
 	 */
@@ -639,7 +639,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Export meta data.
 	 *
-	 * @since 3.1.0
+	 * @since WC-3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @param array      $row Row data.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Archive all "since" lines by adding a WC- prefix to the version numbers for all files in folders includes>api, includes>cli, includes>customizer, includes>data-stores, includes>emails and includes>export .

### How to test the changes in this Pull Request:

1. Check files changes in PR

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

Archive "since" lines by adding a WC- prefix to version numbers in api, cli, customizer, data-stores, emails & export folders.
