### PR TITLE
Fix broken checks for supported themes

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -401,22 +401,16 @@ final class WooCommerce {
 	 * @since WC-3.3.0
 	 */
 	private function theme_support_includes() {
-		if ( wc_is_active_theme( array( 'twentynineteen', 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' ) ) ) {
+		if ( wc_is_active_theme( array( 'classicpress-twentyseventeen', 'classicpress-twentysixteen', 'classicpress-twentyfifteen', 'twentyseventeen', 'twentysixteen', 'twentyfifteen', ) ) ) {
 			switch ( get_template() ) {
-				case 'twentyten':
-					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-ten.php';
+				case 'classicpress-twentyfifteen':
+					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-fifteen.php';
 					break;
-				case 'twentyeleven':
-					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-eleven.php';
+				case 'classicpress-twentysixteen':
+					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-sixteen.php';
 					break;
-				case 'twentytwelve':
-					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twelve.php';
-					break;
-				case 'twentythirteen':
-					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-thirteen.php';
-					break;
-				case 'twentyfourteen':
-					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-fourteen.php';
+				case 'classicpress-twentyseventeen':
+					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-seventeen.php';
 					break;
 				case 'twentyfifteen':
 					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-fifteen.php';
@@ -426,9 +420,6 @@ final class WooCommerce {
 					break;
 				case 'twentyseventeen':
 					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-seventeen.php';
-					break;
-				case 'twentynineteen':
-					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-nineteen.php';
 					break;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
WooCommerce already supports theme versions from twentyten all the way to twentyseventeen. We should add this for ClassicPress child themes too.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #32.

### How to test the changes in this Pull Request:

1.  Install `classic-commerce` in `wp-content\plugins` folder
2. Activate plugin
3. Install using any of the 3 themes or their child themes ('classicpress-twentyseventeen', 'classicpress-twentysixteen', 'classicpress-twentyfifteen', 'twentyseventeen', 'twentysixteen', 'twentyfifteen')

### Changelog entry

> Add ClassicPress child themes support check.