### PR TITLE
Fix broken link to CP forum in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We recommend all developers follow the [Issues](https://github.com/ClassicPress-
 To disclose a security issue to our team. (security@classicpress.net)
 
 ## Support
-This repository is most suitable for development but can also be used for support. We will add a support tag to your issue. However, this might take a little longer to get a response. You can also use the dedicated support area on the [ClassicPress community forum](https://forums.classicpress.net/c/support/classic-commerce/").
+This repository is most suitable for development but can also be used for support. We will add a support tag to your issue. However, this might take a little longer to get a response. You can also use the dedicated support area on the [ClassicPress community forum](https://forums.classicpress.net/c/support/classic-commerce/).
 
 ## Contributing to Classic Commerce
 If you have a patch or have stumbled upon an issue with Classic Commerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md) for more information about how you can do this.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix broken link to CP forum in readme by removing the extraneous double quote mark at end.

### How to test the changes in this Pull Request:

1. Check out file change in PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix broken link to CP forum in readme.