### PR TITLE
Add roadmap link to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You can browse the source, look at open issues and keep track of development her
 
 We recommend all developers follow the [Issues](https://github.com/ClassicPress-research/classic-commerce/issues) and [Pull Requests](https://github.com/ClassicPress-research/classic-commerce/pulls) for the latest development updates.
 
+## Roadmap
+You can follow up on the development cycle by reading our [roadmap](https://github.com/ClassicPress-research/classic-commerce/wiki/Plugin-Roadmap).
 
 ## Documentation
 * [WooCommerce Documentation](https://docs.woocommerce.com/documentation/plugins/woocommerce/)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Add a roadmap link to wiki. 
Closes #16.

### Changelog entry

> Add roadmap link.