### PR TITLE
Remove spaces in the packages name

### DIFF
--- a/i18n/continents.php
+++ b/i18n/continents.php
@@ -4,7 +4,7 @@
  *
  * Returns an array of continents.
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.5.0
  */
 

--- a/i18n/countries.php
+++ b/i18n/countries.php
@@ -4,7 +4,7 @@
  *
  * Returns an array of countries and codes.
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.5.0
  */
 

--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -2,7 +2,7 @@
 /**
  * Locales information
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.5.0
  */
 

--- a/i18n/states/AO.php
+++ b/i18n/states/AO.php
@@ -2,7 +2,7 @@
 /**
  * Angola states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-1.0.0
  */
 

--- a/i18n/states/AR.php
+++ b/i18n/states/AR.php
@@ -2,7 +2,7 @@
 /**
  * Argentinian provinces
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.4.0
  */
 

--- a/i18n/states/AU.php
+++ b/i18n/states/AU.php
@@ -2,7 +2,7 @@
 /**
  * Australian states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/BD.php
+++ b/i18n/states/BD.php
@@ -2,7 +2,7 @@
 /**
  * Bangladeshi states (districts)
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.5.3
  */
 

--- a/i18n/states/BG.php
+++ b/i18n/states/BG.php
@@ -2,7 +2,7 @@
 /**
  * Bulgarian states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/BO.php
+++ b/i18n/states/BO.php
@@ -2,7 +2,7 @@
 /**
  * Bolivian states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.1.0
  */
 

--- a/i18n/states/BR.php
+++ b/i18n/states/BR.php
@@ -2,7 +2,7 @@
 /**
  * Brazillian states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/CA.php
+++ b/i18n/states/CA.php
@@ -2,7 +2,7 @@
 /**
  * Canadian states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/CN.php
+++ b/i18n/states/CN.php
@@ -2,7 +2,7 @@
 /**
  * Chinese states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/ES.php
+++ b/i18n/states/ES.php
@@ -2,7 +2,7 @@
 /**
  * Spain states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.11
  */
 

--- a/i18n/states/GR.php
+++ b/i18n/states/GR.php
@@ -2,7 +2,7 @@
 /**
  * Greek Regions
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.3.0
  */
 

--- a/i18n/states/HK.php
+++ b/i18n/states/HK.php
@@ -2,7 +2,7 @@
 /**
  * Hong Kong states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/HU.php
+++ b/i18n/states/HU.php
@@ -2,7 +2,7 @@
 /**
  * Hungary states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/ID.php
+++ b/i18n/states/ID.php
@@ -2,7 +2,7 @@
 /**
  * Indonesia Provinces
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/IE.php
+++ b/i18n/states/IE.php
@@ -2,7 +2,7 @@
 /**
  * Republic of Ireland
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.0.0
  */
 

--- a/i18n/states/IN.php
+++ b/i18n/states/IN.php
@@ -2,7 +2,7 @@
 /**
  * Indian states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/IR.php
+++ b/i18n/states/IR.php
@@ -2,7 +2,7 @@
 /**
  * Iran States
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.2.3
  */
 

--- a/i18n/states/IT.php
+++ b/i18n/states/IT.php
@@ -2,7 +2,7 @@
 /**
  * Italy Provinces
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/JP.php
+++ b/i18n/states/JP.php
@@ -2,7 +2,7 @@
 /**
  * Japan States
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  *
  * English notation of prefectures conform to the notation of Japan Post.

--- a/i18n/states/LR.php
+++ b/i18n/states/LR.php
@@ -2,7 +2,7 @@
 /**
  * Liberia provinces
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.0.0
  */
 

--- a/i18n/states/MD.php
+++ b/i18n/states/MD.php
@@ -8,7 +8,7 @@
  * https://en.wikipedia.org/wiki/ISO_3166-2:MD
  * https://en.wikipedia.org/wiki/Romanian_alphabet#Unicode_and_HTML
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.3.0
  */
 

--- a/i18n/states/MX.php
+++ b/i18n/states/MX.php
@@ -2,7 +2,7 @@
 /**
  * Mexico States
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.2.9
  */
 

--- a/i18n/states/MY.php
+++ b/i18n/states/MY.php
@@ -2,7 +2,7 @@
 /**
  * Malaysian states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/NG.php
+++ b/i18n/states/NG.php
@@ -2,7 +2,7 @@
 /**
  * Nigerian provinces
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.0.0
  */
 

--- a/i18n/states/NP.php
+++ b/i18n/states/NP.php
@@ -2,7 +2,7 @@
 /**
  * Nepal states (Zones)
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.2.5
  */
 

--- a/i18n/states/NZ.php
+++ b/i18n/states/NZ.php
@@ -2,7 +2,7 @@
 /**
  * New Zealand States
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.3.0
  */
 

--- a/i18n/states/PE.php
+++ b/i18n/states/PE.php
@@ -2,7 +2,7 @@
 /**
  * Peru states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.1.0
  */
 

--- a/i18n/states/PH.php
+++ b/i18n/states/PH.php
@@ -2,7 +2,7 @@
 /**
  * Philippines Provinces
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.4.0
  */
 

--- a/i18n/states/PK.php
+++ b/i18n/states/PK.php
@@ -2,7 +2,7 @@
 /**
  * Pakistan's states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.0.0
  */
 

--- a/i18n/states/PY.php
+++ b/i18n/states/PY.php
@@ -2,7 +2,7 @@
 /**
  * Paraguay states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.5.0
  */
 

--- a/i18n/states/RO.php
+++ b/i18n/states/RO.php
@@ -5,7 +5,7 @@
  * For more details check:
  * https://ro.wikipedia.org/wiki/Jude%C8%9Bele_Rom%C3%A2niei
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.1.0
  */
 

--- a/i18n/states/TH.php
+++ b/i18n/states/TH.php
@@ -2,7 +2,7 @@
 /**
  * Thailand states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-3.4.0
  */
 

--- a/i18n/states/TR.php
+++ b/i18n/states/TR.php
@@ -2,7 +2,7 @@
 /**
  * Turkey States
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/TZ.php
+++ b/i18n/states/TZ.php
@@ -4,7 +4,7 @@
  *
  * Based on English names published at https://en.wikipedia.org/wiki/ISO_3166-2:TZ
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/UG.php
+++ b/i18n/states/UG.php
@@ -4,7 +4,7 @@
  *
  * Based on English names published at https://en.wikipedia.org/wiki/ISO_3166-2:UG
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 global $states;

--- a/i18n/states/US.php
+++ b/i18n/states/US.php
@@ -2,7 +2,7 @@
 /**
  * United States
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/i18n/states/ZA.php
+++ b/i18n/states/ZA.php
@@ -2,7 +2,7 @@
 /**
  * South African states
  *
- * @package Classic Commerce/i18n
+ * @package ClassicCommerce/i18n
  * @version WC-2.0.0
  */
 

--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/auth/footer.php
+++ b/templates/auth/footer.php
@@ -8,7 +8,7 @@
  *
  * @see 	https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Auth
+ * @package ClassicCommerce/Templates/Auth
  * @version WC-2.4.0
  */
 

--- a/templates/auth/form-grant-access.php
+++ b/templates/auth/form-grant-access.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Auth
+ * @package ClassicCommerce/Templates/Auth
  * @version WC-2.4.0
  */
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/auth/form-login.php
+++ b/templates/auth/form-login.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Auth
+ * @package ClassicCommerce/Templates/Auth
  * @version WC-3.4.0
  */
 

--- a/templates/auth/header.php
+++ b/templates/auth/header.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Auth
+ * @package ClassicCommerce/Templates/Auth
  * @version WC-2.4.0
  */
 

--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/cart/cart-item-data.php
+++ b/templates/cart/cart-item-data.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.4.0
  */
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -9,7 +9,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/cart/cart-totals.php
+++ b/templates/cart/cart-totals.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.3.6
  */
 

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/cart/proceed-to-checkout-button.php
+++ b/templates/cart/proceed-to-checkout-button.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.4.0
  */
 

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/checkout/cart-errors.php
+++ b/templates/checkout/cart-errors.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.9
  */
 

--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.4
  */
 

--- a/templates/checkout/form-login.php
+++ b/templates/checkout/form-login.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/checkout/form-shipping.php
+++ b/templates/checkout/form-shipping.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.9
  */
 

--- a/templates/checkout/order-receipt.php
+++ b/templates/checkout/order-receipt.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.2.0
  */
 

--- a/templates/checkout/payment-method.php
+++ b/templates/checkout/payment-method.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/checkout/payment.php
+++ b/templates/checkout/payment.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/checkout/terms.php
+++ b/templates/checkout/terms.php
@@ -2,7 +2,7 @@
 /**
  * Checkout terms and conditions area.
  *
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.2.0
  */
 

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/content-product_cat.php
+++ b/templates/content-product_cat.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.6.1
  */
 

--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -6,7 +6,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.2
  */
 

--- a/templates/content-widget-reviews.php
+++ b/templates/content-widget-reviews.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/HTML
+ * @package ClassicCommerce/Templates/Emails/HTML
  * @version WC-3.5.0
  */
 

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.2
  */
 

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/customer-on-hold-order.php
+++ b/templates/emails/customer-on-hold-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/customer-refunded-order.php
+++ b/templates/emails/customer-refunded-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.2.1
  */
 

--- a/templates/emails/email-customer-details.php
+++ b/templates/emails/email-customer-details.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-2.5.0
  */
 

--- a/templates/emails/email-downloads.php
+++ b/templates/emails/email-downloads.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-2.3.0
  */
 

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-2.4.0
  */
 

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.3.1
  */
 

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.3.0
  */
 

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.2
  */
 

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/customer-on-hold-order.php
+++ b/templates/emails/plain/customer-on-hold-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/customer-refunded-order.php
+++ b/templates/emails/plain/customer-refunded-order.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.4.0
  */
 

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -9,7 +9,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.4.0
  */
 

--- a/templates/emails/plain/email-downloads.php
+++ b/templates/emails/plain/email-downloads.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates/Emails
+ * @package ClassicCommerce/Templates/Emails
  * @version WC-3.5.0
  */
 

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates/Emails/Plain
+ * @package ClassicCommerce/Templates/Emails/Plain
  * @version WC-3.2.0
  */
 

--- a/templates/global/breadcrumb.php
+++ b/templates/global/breadcrumb.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.3.0
  * @see     woocommerce_breadcrumb()
  */

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/global/sidebar.php
+++ b/templates/global/sidebar.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/loop/loop-end.php
+++ b/templates/loop/loop-end.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.0.0
  */
 

--- a/templates/loop/loop-start.php
+++ b/templates/loop/loop-start.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/loop/no-products-found.php
+++ b/templates/loop/no-products-found.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.0.0
  */
 

--- a/templates/loop/orderby.php
+++ b/templates/loop/orderby.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/loop/pagination.php
+++ b/templates/loop/pagination.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.1
  */
 

--- a/templates/loop/price.php
+++ b/templates/loop/price.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/loop/sale-flash.php
+++ b/templates/loop/sale-flash.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.6.0
  */
 

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.2.0
  */
 

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/myaccount/form-edit-address.php
+++ b/templates/myaccount/form-edit-address.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/myaccount/form-lost-password.php
+++ b/templates/myaccount/form-lost-password.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.2
  */
 

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/myaccount/lost-password-confirmation.php
+++ b/templates/myaccount/lost-password-confirmation.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.2
  */
 

--- a/templates/myaccount/my-account.php
+++ b/templates/myaccount/my-account.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.6.0
  */
 

--- a/templates/myaccount/navigation.php
+++ b/templates/myaccount/navigation.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.6.0
  */
 

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.2.0
  */
 

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.6.0
  */
 

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/order/form-tracking.php
+++ b/templates/order/form-tracking.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.4
  */
 

--- a/templates/order/order-details-item.php
+++ b/templates/order/order-details-item.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.2
  */
 

--- a/templates/order/order-downloads.php
+++ b/templates/order/order-downloads.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  Automattic
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/order/tracking.php
+++ b/templates/order/tracking.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.2.0
  */
 

--- a/templates/product-searchform.php
+++ b/templates/product-searchform.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-product.php
+++ b/templates/single-product.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.1
  */
 

--- a/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -3,7 +3,7 @@
  * Single variation cart button
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/single-product/add-to-cart/variation.php
+++ b/templates/single-product/add-to-cart/variation.php
@@ -7,7 +7,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.5.0
  */
 

--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/single-product/photoswipe.php
+++ b/templates/single-product/photoswipe.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/single-product/price.php
+++ b/templates/single-product/price.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.1.0
  */
 

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.1
  */
 

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.1
  */
 

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.1.0
  */
 

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/single-product/review-meta.php
+++ b/templates/single-product/review-meta.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.4.0
  */
 

--- a/templates/single-product/review-rating.php
+++ b/templates/single-product/review-rating.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.1.0
  */
 

--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -10,7 +10,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.6.0
  */
 

--- a/templates/single-product/sale-flash.php
+++ b/templates/single-product/sale-flash.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 

--- a/templates/single-product/share.php
+++ b/templates/single-product/share.php
@@ -9,7 +9,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.5.0
  */
 

--- a/templates/single-product/short-description.php
+++ b/templates/single-product/short-description.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  Automattic
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.3.0
  */
 

--- a/templates/single-product/stock.php
+++ b/templates/single-product/stock.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/single-product/tabs/additional-information.php
+++ b/templates/single-product/tabs/additional-information.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/single-product/tabs/description.php
+++ b/templates/single-product/tabs/description.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.0.0
  */
 

--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-2.4.0
  */
 

--- a/templates/single-product/title.php
+++ b/templates/single-product/title.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -8,7 +8,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-3.0.0
  */
 

--- a/templates/taxonomy-product_cat.php
+++ b/templates/taxonomy-product_cat.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 

--- a/templates/taxonomy-product_tag.php
+++ b/templates/taxonomy-product_tag.php
@@ -7,7 +7,7 @@
  * Template Overrides: https://docs.woocommerce.com/document/template-structure/#section-1
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package Classic Commerce/Templates
+ * @package ClassicCommerce/Templates
  * @version WC-1.6.4
  */
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Remove spaces in the `@package ClassicCommerce` packages name.

