### PR TITLE
Change woocommerce text to cc in tests folder

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-# WooCommerce Unit Tests
+# ClassicCommerce Unit Tests
 
 ## Initial Setup
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Unit Tests Bootstrap
+ * ClassicCommerce Unit Tests Bootstrap
  *
  * @since WC-2.2
  */
@@ -69,7 +69,7 @@ class WC_Unit_Tests_Bootstrap {
 	}
 
 	/**
-	 * Install WooCommerce after the test environment and WC have been loaded.
+	 * Install ClassicCommerce after the test environment and WC have been loaded.
 	 *
 	 * @since WC-2.2
 	 */

--- a/tests/cli/features/customer.feature
+++ b/tests/cli/features/customer.feature
@@ -1,4 +1,4 @@
-Feature: Manage WooCommerce customers
+Feature: Manage ClassicCommerce customers
 
 Background:
 

--- a/tests/cli/features/customer_download.feature
+++ b/tests/cli/features/customer_download.feature
@@ -1,4 +1,4 @@
-Feature: List WooCommerce customer downloads
+Feature: List ClassicCommerce customer downloads
 
 Background:
 

--- a/tests/cli/features/payment_gateway.feature
+++ b/tests/cli/features/payment_gateway.feature
@@ -1,4 +1,4 @@
-Feature: Manage WooCommerce Payment Gateways
+Feature: Manage ClassicCommerce Payment Gateways
 
 Background:
 

--- a/tests/cli/features/product.feature
+++ b/tests/cli/features/product.feature
@@ -1,4 +1,4 @@
-Feature: Manage WooCommerce Products
+Feature: Manage ClassicCommerce Products
 
 Background:
 

--- a/tests/cli/features/product_review.feature
+++ b/tests/cli/features/product_review.feature
@@ -1,4 +1,4 @@
-Feature: Manage WooCommerce Product Reviews
+Feature: Manage ClassicCommerce Product Reviews
 
 Background:
 

--- a/tests/cli/features/shop_coupon.feature
+++ b/tests/cli/features/shop_coupon.feature
@@ -1,4 +1,4 @@
-Feature: Manage WooCommerce Coupons
+Feature: Manage ClassicCommerce Coupons
 
 Background:
 

--- a/tests/framework/class-wc-mock-session-handler.php
+++ b/tests/framework/class-wc-mock-session-handler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Mock Session Handler
+ * ClassicCommerce Mock Session Handler
  *
  * @since WC-2.2
  */

--- a/tests/framework/class-wc-unit-test-case.php
+++ b/tests/framework/class-wc-unit-test-case.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Base test case for all WooCommerce tests.
+ * Base test case for all ClassicCommerce tests.
  *
- * @package WooCommerce\Tests
+ * @package ClassicCommerce\Tests
  */
 
 /**
  * WC Unit Test Case.
  *
- * Provides WooCommerce-specific setup/tear down/assert methods, custom factories,
+ * Provides ClassicCommerce-specific setup/tear down/assert methods, custom factories,
  * and helper functions.
  *
  * @since WC-2.2

--- a/tests/framework/helpers/class-wc-helper-customer.php
+++ b/tests/framework/helpers/class-wc-helper-customer.php
@@ -92,7 +92,7 @@ class WC_Helper_Customer {
 	}
 
 	/**
-	 * Get the "Tax Based On" WooCommerce option.
+	 * Get the "Tax Based On" ClassicCommerce option.
 	 *
 	 * @return string base or billing
 	 */
@@ -119,7 +119,7 @@ class WC_Helper_Customer {
 	}
 
 	/**
-	 * Set the "Tax Based On" WooCommerce option.
+	 * Set the "Tax Based On" ClassicCommerce option.
 	 *
 	 * @param string $default_shipping_method Shipping Method slug
 	 */

--- a/tests/unit-tests/account/functions.php
+++ b/tests/unit-tests/account/functions.php
@@ -2,7 +2,7 @@
 /**
  * Account function tests
  *
- * @package WooCommerce\Tests\Account
+ * @package ClassicCommerce\Tests\Account
  */
 
 /**

--- a/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -2,7 +2,7 @@
 /**
  * Class WC_Tests_Admin_Report file.
  *
- * @package WooCommerce\Tests\Admin\Reports
+ * @package ClassicCommerce\Tests\Admin\Reports
  */
 
 /**
@@ -11,7 +11,7 @@
 class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 
 	/**
-	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
+	 * Load the necessary files, as they're not automatically loaded by ClassicCommerce.
 	 *
 	 */
 	public static function setUpBeforeClass() {

--- a/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -2,7 +2,7 @@
 /**
  * Class WC_Tests_Report_Sales_By_Date file.
  *
- * @package WooCommerce\Tests\Admin\Reports
+ * @package ClassicCommerce\Tests\Admin\Reports
  */
 
 /**
@@ -11,7 +11,7 @@
 class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 	/**
-	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
+	 * Load the necessary files, as they're not automatically loaded by ClassicCommerce.
 	 */
 	public static function setUpBeforeClass() {
 		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-admin-report.php';

--- a/tests/unit-tests/api/coupons.php
+++ b/tests/unit-tests/api/coupons.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Coupon API Tests
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/api/customers.php
+++ b/tests/unit-tests/api/customers.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Customers REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/functions.php
+++ b/tests/unit-tests/api/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * REST API Functions.
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since WC-2.6.0
  */
 class WC_Tests_API_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the orders REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/api/payment-gateways.php
+++ b/tests/unit-tests/api/payment-gateways.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Payment Gateways REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/product-reviews.php
+++ b/tests/unit-tests/api/product-reviews.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the product reviews REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -2,7 +2,7 @@
 /**
  * Tests for Variations API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/products.php
+++ b/tests/unit-tests/api/products.php
@@ -2,7 +2,7 @@
 /**
  * Tests for Products API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/reports-coupons-totals.php
+++ b/tests/unit-tests/api/reports-coupons-totals.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the reports coupons totals REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/reports-customers-totals.php
+++ b/tests/unit-tests/api/reports-customers-totals.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the reports customers totals REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/reports-orders-totals.php
+++ b/tests/unit-tests/api/reports-orders-totals.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the reports orders totals REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/reports-products-totals.php
+++ b/tests/unit-tests/api/reports-products-totals.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the reports products totals REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/reports-reviews-totals.php
+++ b/tests/unit-tests/api/reports-reviews-totals.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the reports reviews totals REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/settings.php
+++ b/tests/unit-tests/api/settings.php
@@ -2,7 +2,7 @@
 /**
  * Settings API Tests.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/shipping-methods.php
+++ b/tests/unit-tests/api/shipping-methods.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Shipping Methods REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -3,7 +3,7 @@
 /**
  * Shipping Zones API Tests
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -2,13 +2,13 @@
 /**
  * Class WC_Tests_REST_System_Status file.
  *
- * @package WooCommerce/Tests
+ * @package ClassicCommerce/Tests
  */
 
 /**
  * System Status REST Tests.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/api/v2/coupons.php
+++ b/tests/unit-tests/api/v2/coupons.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Coupon API Tests
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since WC-3.0.0
  */
 class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/api/v2/customers.php
+++ b/tests/unit-tests/api/v2/customers.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Customers REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since WC-3.0.0
  */
 

--- a/tests/unit-tests/api/v2/orders.php
+++ b/tests/unit-tests/api/v2/orders.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the orders REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since WC-3.0.0
  */
 class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/api/v2/payment-gateways.php
+++ b/tests/unit-tests/api/v2/payment-gateways.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Payment Gateways REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since WC-3.0.0
  */
 

--- a/tests/unit-tests/api/v2/product-reviews.php
+++ b/tests/unit-tests/api/v2/product-reviews.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the product reviews REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.5.0
  */
 

--- a/tests/unit-tests/api/v2/product-variations.php
+++ b/tests/unit-tests/api/v2/product-variations.php
@@ -2,7 +2,7 @@
 /**
  * Tests for Variations API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.0.0
  */
 

--- a/tests/unit-tests/api/v2/products.php
+++ b/tests/unit-tests/api/v2/products.php
@@ -2,7 +2,7 @@
 /**
  * Tests for Products API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.0.0
  */
 

--- a/tests/unit-tests/api/v2/settings.php
+++ b/tests/unit-tests/api/v2/settings.php
@@ -2,7 +2,7 @@
 /**
  * Settings API Tests.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.0.0
  */
 

--- a/tests/unit-tests/api/v2/shipping-methods.php
+++ b/tests/unit-tests/api/v2/shipping-methods.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Shipping Methods REST API.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.0.0
  */
 

--- a/tests/unit-tests/api/v2/shipping-zones.php
+++ b/tests/unit-tests/api/v2/shipping-zones.php
@@ -2,7 +2,7 @@
 
 /**
  * Shipping Zones API Tests
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.0.0
  */
 class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/api/v2/system-status.php
+++ b/tests/unit-tests/api/v2/system-status.php
@@ -2,13 +2,13 @@
 /**
  * Class WC_Tests_REST_System_Status file.
  *
- * @package WooCommerce/Tests
+ * @package ClassicCommerce/Tests
  */
 
 /**
  * System Status REST Tests.
  *
- * @package WooCommerce\Tests\API
+ * @package ClassicCommerce\Tests\API
  * @since 3.0
  */
 class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {

--- a/tests/unit-tests/attributes/functions.php
+++ b/tests/unit-tests/attributes/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Functions.
- * @package WooCommerce\Tests\Attributes
+ * @package ClassicCommerce\Tests\Attributes
  * @since 3.2.0
  */
 class WC_Tests_Attributes_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/cart/cart-fees.php
+++ b/tests/unit-tests/cart/cart-fees.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Cart_Fees.
- * @package WooCommerce\Tests\Cart
+ * @package ClassicCommerce\Tests\Cart
  * @since 3.2.0
  */
 class WC_Tests_WC_Cart_Fees extends WC_Unit_Test_Case {

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Cart.
- * @package WooCommerce\Tests\Cart
+ * @package ClassicCommerce\Tests\Cart
  */
 class WC_Tests_Cart extends WC_Unit_Test_Case {
 	public function tearDown() {

--- a/tests/unit-tests/cart/functions.php
+++ b/tests/unit-tests/cart/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Functions.
- * @package WooCommerce\Tests\Cart
+ * @package ClassicCommerce\Tests\Cart
  */
 class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/core/main-class.php
+++ b/tests/unit-tests/core/main-class.php
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * WooCommerce class.
+ * ClassicCommerce class.
  *
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  */
 class WC_Test_WooCommerce extends WC_Unit_Test_Case {
 
 	/**
-	 * WooCommerce instance.
+	 * ClassicCommerce instance.
 	 *
 	 * @var \WooCommerce instance
 	 */

--- a/tests/unit-tests/countries/countries.php
+++ b/tests/unit-tests/countries/countries.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Countries.
- * @package WooCommerce\Tests\Countries
+ * @package ClassicCommerce\Tests\Countries
  */
 class WC_Tests_Countries extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Coupon.
- * @package WooCommerce\Tests\Coupon
+ * @package ClassicCommerce\Tests\Coupon
  * @group coupons
  */
 class WC_Tests_Coupon extends WC_Unit_Test_Case {

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Data Store Tests: Tests WC_Coupon's WC_Data_Store.
- * @package WooCommerce\Tests\Coupon
+ * @package ClassicCommerce\Tests\Coupon
  */
 class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Data Tests: Tests WC_Coupon's WC_Data Implementation.
- * @package WooCommerce\Tests\Coupon
+ * @package ClassicCommerce\Tests\Coupon
  */
 class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/coupon/functions.php
+++ b/tests/unit-tests/coupon/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Functions.
- * @package WooCommerce\Tests\Coupon
+ * @package ClassicCommerce\Tests\Coupon
  * @since WC-2.2
  */
 class WC_Tests_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/crud/data-store.php
+++ b/tests/unit-tests/crud/data-store.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Data Store Tests
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  * @since WC-3.0.0
  */
 class WC_Tests_Data_Store extends WC_Unit_Test_Case {

--- a/tests/unit-tests/crud/data.php
+++ b/tests/unit-tests/crud/data.php
@@ -2,7 +2,7 @@
 
 /**
  * Meta
- * @package WooCommerce\Tests\CRUD
+ * @package ClassicCommerce\Tests\CRUD
  */
 class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/crud/meta.php
+++ b/tests/unit-tests/crud/meta.php
@@ -2,7 +2,7 @@
 /**
  * Test meta for https://github.com/woocommerce/woocommerce/issues/13533.
  *
- * @package WooCommerce\Tests\CRUD
+ * @package ClassicCommerce\Tests\CRUD
  */
 class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/crud/query.php
+++ b/tests/unit-tests/crud/query.php
@@ -2,7 +2,7 @@
 
 /**
  * WC_Object_Query tests
- * @package WooCommerce\Tests\CRUD
+ * @package ClassicCommerce\Tests\CRUD
  * @since 3.1.0
  */
 class WC_Tests_WC_Object_Query extends WC_Unit_Test_Case {

--- a/tests/unit-tests/crud/refunds.php
+++ b/tests/unit-tests/crud/refunds.php
@@ -2,7 +2,7 @@
 
 /**
  * Meta
- * @package WooCommerce\Tests\CRUD
+ * @package ClassicCommerce\Tests\CRUD
  */
 class WC_Tests_CRUD_Refunds extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/customer/class-wc-customer-download-log-data-store.php
+++ b/tests/unit-tests/customer/class-wc-customer-download-log-data-store.php
@@ -3,7 +3,7 @@
  * Class WC_Tests_Customer_Download_Log_Data_Store file.
  *
  * @version  3.5.0
- * @package WooCommerce\Tests\Customer
+ * @package ClassicCommerce\Tests\Customer
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/tests/unit-tests/customer/class-wc-tests-customer-download.php
+++ b/tests/unit-tests/customer/class-wc-tests-customer-download.php
@@ -2,14 +2,14 @@
 /**
  * WC_Customer_Download tests file.
  *
- * @package WooCommerce\Tests\Customer
+ * @package ClassicCommerce\Tests\Customer
  */
 
 /**
  * Class WC_Customer_Download.
  *
  * @since 3.3.0
- * @package WooCommerce\Tests\Customer
+ * @package ClassicCommerce\Tests\Customer
  */
 class WC_Tests_Customer_Download extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -2,7 +2,7 @@
 
 /**
  * Class CustomerCRUD.
- * @package WooCommerce\Tests\Customer
+ * @package ClassicCommerce\Tests\Customer
  */
 class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/customer/customer-download-log.php
+++ b/tests/unit-tests/customer/customer-download-log.php
@@ -3,7 +3,7 @@
 /**
  * Class Customer_Download_Log.
  * @since 3.3.0
- * @package WooCommerce\Tests\Customer
+ * @package ClassicCommerce\Tests\Customer
  */
 class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/customer/customer.php
+++ b/tests/unit-tests/customer/customer.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Customer.
- * @package WooCommerce\Tests\Customer
+ * @package ClassicCommerce\Tests\Customer
  */
 class WC_Tests_Customer extends WC_Unit_Test_Case {
 
@@ -15,7 +15,7 @@ class WC_Tests_Customer extends WC_Unit_Test_Case {
 		$base_store_address = WC_Helper_Customer::get_expected_store_location();
 		$customer_address   = $customer->get_taxable_address(); // Default is geolocation!
 
-		// Get the original settings for the session and the WooCommerce options
+		// Get the original settings for the session and the ClassicCommerce options
 		$original_chosen_shipping_methods = WC_Helper_Customer::get_chosen_shipping_methods();
 		$original_tax_based_on            = WC_Helper_Customer::get_tax_based_on();
 		$original_customer_details        = WC_Helper_Customer::get_customer_details();
@@ -58,7 +58,7 @@ class WC_Tests_Customer extends WC_Unit_Test_Case {
 	 */
 	public function test_is_customer_outside_base() {
 
-		// Get the original settings for the session and the WooCommerce options
+		// Get the original settings for the session and the ClassicCommerce options
 		$original_chosen_shipping_methods = WC_Helper_Customer::get_chosen_shipping_methods();
 		$original_tax_based_on            = WC_Helper_Customer::get_tax_based_on();
 		$original_customer_details        = WC_Helper_Customer::get_customer_details();

--- a/tests/unit-tests/customer/functions.php
+++ b/tests/unit-tests/customer/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Customer functions.
- * @package WooCommerce\Tests\Customer
+ * @package ClassicCommerce\Tests\Customer
  */
 class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -2,7 +2,7 @@
 
 /**
  * Test for the discounts class.
- * @package WooCommerce\Tests\Discounts
+ * @package ClassicCommerce\Tests\Discounts
  */
 class WC_Tests_Discounts extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/exporter/product.php
+++ b/tests/unit-tests/exporter/product.php
@@ -2,7 +2,7 @@
 
 /**
  * Meta
- * @package WooCommerce\Tests\Exporter
+ * @package ClassicCommerce\Tests\Exporter
  */
 class WC_Tests_Product_CSV_Exporter extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -2,7 +2,7 @@
 /**
  * Formatting functions
  *
- * @package WooCommerce\Tests\Formatting
+ * @package ClassicCommerce\Tests\Formatting
  */
 
 /**

--- a/tests/unit-tests/gateways/gateways.php
+++ b/tests/unit-tests/gateways/gateways.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests for gateways.
  *
- * @package WooCommerce\Tests\Gateways
+ * @package ClassicCommerce\Tests\Gateways
  */
 class WC_Tests_Gateways extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests for Paypal standard gateway request.
  *
- * @package WooCommerce\Tests\Gateways\Paypal
+ * @package ClassicCommerce\Tests\Gateways\Paypal
  */
 class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/geolocation/class-wc-test-gelocation.php
+++ b/tests/unit-tests/geolocation/class-wc-test-gelocation.php
@@ -2,7 +2,7 @@
 /**
  * Class Functions.
  *
- * @package WooCommerce\Tests\Geolocation
+ * @package ClassicCommerce\Tests\Geolocation
  */
 
 /**

--- a/tests/unit-tests/geolocation/class-wc-tests-geolite-integration.php
+++ b/tests/unit-tests/geolocation/class-wc-tests-geolite-integration.php
@@ -2,7 +2,7 @@
 /**
  * Class Functions.
  *
- * @package WooCommerce\Tests\Geolocation
+ * @package ClassicCommerce\Tests\Geolocation
  */
 
 /**

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -2,7 +2,7 @@
 
 /**
  * Meta
- * @package WooCommerce\Tests\Importer
+ * @package ClassicCommerce\Tests\Importer
  */
 class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/importer/tax.php
+++ b/tests/unit-tests/importer/tax.php
@@ -2,7 +2,7 @@
 
 /**
  * Meta
- * @package WooCommerce\Tests\Importer
+ * @package ClassicCommerce\Tests\Importer
  */
 class WC_Tests_Tax_CSV_Importer extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/integrations/class-dummy-integration.php
+++ b/tests/unit-tests/integrations/class-dummy-integration.php
@@ -2,7 +2,7 @@
 /**
  * Dummy integration class
  *
- * @package WooCommerce\Tests\Integrations
+ * @package ClassicCommerce\Tests\Integrations
  */
 
 /**

--- a/tests/unit-tests/integrations/class-wc-tests-integrations.php
+++ b/tests/unit-tests/integrations/class-wc-tests-integrations.php
@@ -2,7 +2,7 @@
 /**
  * Class Functions.
  *
- * @package WooCommerce\Tests\Integrations
+ * @package ClassicCommerce\Tests\Integrations
  */
 
 /**

--- a/tests/unit-tests/libraries/wp-background-process.php
+++ b/tests/unit-tests/libraries/wp-background-process.php
@@ -2,7 +2,7 @@
 /**
  * WP_Background_Processing Tests.
  *
- * @package WooCommerce\Tests\Libraries
+ * @package ClassicCommerce\Tests\Libraries
  */
 
 /**

--- a/tests/unit-tests/log/log-handler-db.php
+++ b/tests/unit-tests/log/log-handler-db.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Tests_Log_Handler_DB
- * @package WooCommerce\Tests\Log
+ * @package ClassicCommerce\Tests\Log
  * @since WC-3.0.0
  */
 class WC_Tests_Log_Handler_DB extends WC_Unit_Test_Case {

--- a/tests/unit-tests/log/log-handler-email.php
+++ b/tests/unit-tests/log/log-handler-email.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Tests_Log_Handler_Email
- * @package WooCommerce\Tests\Log
+ * @package ClassicCommerce\Tests\Log
  * @since WC-3.0.0
  */
 class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
@@ -34,7 +34,7 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 
 		$this->assertEquals(
 			(
-				'You have received the following WooCommerce log messages:'
+				'You have received the following ClassicCommerce log messages:'
 				. PHP_EOL
 				. PHP_EOL
 				. date( 'c', $time ) . ' EMERGENCY msg_emergency'
@@ -50,7 +50,7 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 			$mailer->get_sent( 0 )->body
 		);
 		$this->assertEquals(
-			"[{$site_name}] EMERGENCY: 2 WooCommerce log messages",
+			"[{$site_name}] EMERGENCY: 2 ClassicCommerce log messages",
 			$mailer->get_sent( 0 )->subject
 		);
 		$this->assertEquals( get_option( 'admin_email' ), $mailer->get_recipient( 'to' )->address );
@@ -59,7 +59,7 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 		$handler->send_log_email();
 		$this->assertEquals(
 			(
-				'You have received the following WooCommerce log message:'
+				'You have received the following ClassicCommerce log message:'
 				. PHP_EOL
 				. PHP_EOL
 				. date( 'c', $time ) . ' EMERGENCY msg_emergency'
@@ -96,12 +96,12 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 		$handler->send_log_email();
 
 		$this->assertEquals(
-			"[{$site_name}] DEBUG: 1 WooCommerce log message",
+			"[{$site_name}] DEBUG: 1 ClassicCommerce log message",
 			$mailer->get_sent( 0 )->subject
 		);
 
 		$this->assertEquals(
-			"[{$site_name}] ALERT: 3 WooCommerce log messages",
+			"[{$site_name}] ALERT: 3 ClassicCommerce log messages",
 			$mailer->get_sent( 1 )->subject
 		);
 	}
@@ -210,7 +210,7 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 
 		$this->assertEquals(
 			(
-				'You have received the following WooCommerce log message:'
+				'You have received the following ClassicCommerce log message:'
 				. PHP_EOL
 				. PHP_EOL
 				. date( 'c', $time ) . ' EMERGENCY message 1'
@@ -226,7 +226,7 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 
 		$this->assertEquals(
 			(
-				'You have received the following WooCommerce log message:'
+				'You have received the following ClassicCommerce log message:'
 				. PHP_EOL
 				. PHP_EOL
 				. date( 'c', $time ) . ' EMERGENCY message 2'

--- a/tests/unit-tests/log/log-handler-file.php
+++ b/tests/unit-tests/log/log-handler-file.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Tests_Log_Handler_File
- * @package WooCommerce\Tests\Log
+ * @package ClassicCommerce\Tests\Log
  * @since WC-3.0.0
  */
 class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {

--- a/tests/unit-tests/log/log-levels.php
+++ b/tests/unit-tests/log/log-levels.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Tests_Logger
- * @package WooCommerce\Tests\Log
+ * @package ClassicCommerce\Tests\Log
  * @since WC-3.0.0
  */
 class WC_Tests_Log_Levels extends WC_Unit_Test_Case {

--- a/tests/unit-tests/log/logger.php
+++ b/tests/unit-tests/log/logger.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Tests_Logger
- * @package WooCommerce\Tests\Log
+ * @package ClassicCommerce\Tests\Log
  * @since WC-2.3
  */
 class WC_Tests_Logger extends WC_Unit_Test_Case {

--- a/tests/unit-tests/order-items/class-wc-tests-order-item-product.php
+++ b/tests/unit-tests/order-items/class-wc-tests-order-item-product.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests for the WC_Order_Item_Product class.
  *
- * @package WooCommerce\Tests\Order_Items
+ * @package ClassicCommerce\Tests\Order_Items
  * @since 3.2.0
  */
 

--- a/tests/unit-tests/order-items/functions.php
+++ b/tests/unit-tests/order-items/functions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Order Item Function Tests
- * @package WooCommerce\Tests\Order_Items
+ * @package ClassicCommerce\Tests\Order_Items
  * @since WC-3.0.0
  */
 class WC_Tests_Order_Item_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/order-items/order-item-coupon.php
+++ b/tests/unit-tests/order-items/order-item-coupon.php
@@ -2,7 +2,7 @@
 
 /**
  * Order Item Coupon Tests.
- * @package WooCommerce\Tests\Order_Items
+ * @package ClassicCommerce\Tests\Order_Items
  * @since 3.2.0
  */
 class WC_Tests_Order_Item_Coupon extends WC_Unit_Test_Case {

--- a/tests/unit-tests/order-items/order-item-fee.php
+++ b/tests/unit-tests/order-items/order-item-fee.php
@@ -2,7 +2,7 @@
 
 /**
  * Order Item Fee Tests.
- * @package WooCommerce\Tests\Order_Items
+ * @package ClassicCommerce\Tests\Order_Items
  * @since 3.2.0
  */
 class WC_Tests_Order_Item_Fee extends WC_Unit_Test_Case {

--- a/tests/unit-tests/order-items/order-item-meta.php
+++ b/tests/unit-tests/order-items/order-item-meta.php
@@ -2,7 +2,7 @@
 
 /**
  * Order Item Meta Tests.
- * @package WooCommerce\Tests\Order_Items
+ * @package ClassicCommerce\Tests\Order_Items
  * @since 3.0.8
  */
 class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {

--- a/tests/unit-tests/order-items/order-item-tax.php
+++ b/tests/unit-tests/order-items/order-item-tax.php
@@ -2,7 +2,7 @@
 
 /**
  * Order Item Tax Tests.
- * @package WooCommerce\Tests\Order_Items
+ * @package ClassicCommerce\Tests\Order_Items
  * @since WC-3.0.0
  */
 class WC_Tests_Order_Item_Tax extends WC_Unit_Test_Case {

--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -2,13 +2,13 @@
 /**
  * Class WC_Tests_CRUD_Orders file.
  *
- * @package WooCommerce\Tests\CRUD
+ * @package ClassicCommerce\Tests\CRUD
  */
 
 /**
  * Meta
  *
- * @package WooCommerce\Tests\CRUD
+ * @package ClassicCommerce\Tests\CRUD
  */
 class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/unit-tests/order/class-wc-tests-order-functions.php
@@ -2,13 +2,13 @@
 /**
  * Class WC_Tests_Order_Functions file.
  *
- * @package WooCommerce/Tests
+ * @package ClassicCommerce/Tests
  */
 
 /**
  * Class Functions.
  *
- * @package WooCommerce\Tests\Order
+ * @package ClassicCommerce\Tests\Order
  * @since WC-2.3
  */
 class WC_Tests_Order_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/order/coupons.php
+++ b/tests/unit-tests/order/coupons.php
@@ -2,7 +2,7 @@
 
 /**
  * Order coupon tests.
- * @package WooCommerce\Tests\Orders
+ * @package ClassicCommerce\Tests\Orders
  */
 class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/order/query.php
+++ b/tests/unit-tests/order/query.php
@@ -2,7 +2,7 @@
 
 /**
  * Test WC_Order_Query
- * @package WooCommerce\Tests\Order
+ * @package ClassicCommerce\Tests\Order
  */
 class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/payment-tokens/cc.php
+++ b/tests/unit-tests/payment-tokens/cc.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Payment_Token_CC.
- * @package WooCommerce\Tests\Payment_Tokens
+ * @package ClassicCommerce\Tests\Payment_Tokens
  */
 class WC_Tests_Payment_Token_CC extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/payment-tokens/echeck.php
+++ b/tests/unit-tests/payment-tokens/echeck.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Payment_Token_eCheck.
- * @package WooCommerce\Tests\Payment_Tokens
+ * @package ClassicCommerce\Tests\Payment_Tokens
  */
 class WC_Tests_Payment_Token_eCheck extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/payment-tokens/payment-token.php
+++ b/tests/unit-tests/payment-tokens/payment-token.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class Payment_Token
- * @package WooCommerce\Tests\Payment_Tokens
+ * @package ClassicCommerce\Tests\Payment_Tokens
  */
 class WC_Tests_Payment_Token extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/payment-tokens/payment-tokens.php
+++ b/tests/unit-tests/payment-tokens/payment-tokens.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Payment_Tokens
- * @package WooCommerce\Tests\Payment_Tokens
+ * @package ClassicCommerce\Tests\Payment_Tokens
  */
 class WC_Tests_Payment_Tokens extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/privacy/export.php
+++ b/tests/unit-tests/privacy/export.php
@@ -2,7 +2,7 @@
 /**
  * Privacy data exporter.
  *
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  */
 class WC_Test_Privacy_Export extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/product/class-wc-tests-product-download.php
+++ b/tests/unit-tests/product/class-wc-tests-product-download.php
@@ -2,13 +2,13 @@
 /**
  * Unit tests for the product download class.
  *
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  */
 
 /**
  * WC_Product_Download tests.
  *
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  * @since 3.4.6
  */
 class WC_Tests_Product_Download extends WC_Unit_Test_Case {

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -2,7 +2,7 @@
 /**
  * Data Store Tests: Tests WC_Products's WC_Data_Store.
  *
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  * @since WC-3.0.0
  */
 class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -2,13 +2,13 @@
 /**
  * Unit tests for the product data methods.
  *
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  */
 
 /**
  * Data Functions.
  *
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  * @since WC-3.0.0
  */
 class WC_Tests_Product_Data extends WC_Unit_Test_Case {

--- a/tests/unit-tests/product/factory.php
+++ b/tests/unit-tests/product/factory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Products Factory Tests
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  * @since WC-3.0.0
  */
 class WC_Tests_Product_Factory extends WC_Unit_Test_Case {

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Functions.
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  * @since WC-2.3
  */
 class WC_Tests_Product_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/product/product-simple.php
+++ b/tests/unit-tests/product/product-simple.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Product_Simple.
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  * @since WC-2.3
  */
 class WC_Tests_Product_Simple extends WC_Unit_Test_Case {

--- a/tests/unit-tests/product/product-variable.php
+++ b/tests/unit-tests/product/product-variable.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests for the WC_Product_Variable class.
  *
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  */
 
 /**

--- a/tests/unit-tests/product/product-variation.php
+++ b/tests/unit-tests/product/product-variation.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the WC_Product_Variation class.
  *
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  */
 
 /**

--- a/tests/unit-tests/product/query.php
+++ b/tests/unit-tests/product/query.php
@@ -2,7 +2,7 @@
 
 /**
  * Test WC_Product_Query
- * @package WooCommerce\Tests\Product
+ * @package ClassicCommerce\Tests\Product
  */
 class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/session/class-wc-tests-session-handler.php
+++ b/tests/unit-tests/session/class-wc-tests-session-handler.php
@@ -2,7 +2,7 @@
 /**
  * Class WC_Tests_Session_Handler file.
  *
- * @package WooCommerce\Tests\Session
+ * @package ClassicCommerce\Tests\Session
  */
 
 /**

--- a/tests/unit-tests/settings/register-wp-admin-settings.php
+++ b/tests/unit-tests/settings/register-wp-admin-settings.php
@@ -5,7 +5,7 @@
  * Tests the helper class that makes settings (currently present in wp-admin)
  * available to the REST API.
  *
- * @package WooCommerce\Tests\Settings
+ * @package ClassicCommerce\Tests\Settings
  * @since WC-3.0.0
  */
 class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {

--- a/tests/unit-tests/setup/functions.php
+++ b/tests/unit-tests/setup/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Functions.
- * @package WooCommerce\Tests\Setup
+ * @package ClassicCommerce\Tests\Setup
  */
 class WC_Tests_Setup_Functions extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/shipping-zones/shipping-zone.php
+++ b/tests/unit-tests/shipping-zones/shipping-zone.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Shipping_Zone.
- * @package WooCommerce\Tests\Shipping_Zone
+ * @package ClassicCommerce\Tests\Shipping_Zone
  */
 class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/shipping-zones/shipping-zones.php
+++ b/tests/unit-tests/shipping-zones/shipping-zones.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Shipping_Zones.
- * @package WooCommerce\Tests\Shipping_Zones
+ * @package ClassicCommerce\Tests\Shipping_Zones
  */
 class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -3,7 +3,7 @@
 /**
  * Class WC_Shortcode_Products.
  *
- * @package WooCommerce\Tests\Shortcodes
+ * @package ClassicCommerce\Tests\Shortcodes
  */
 class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Tax.
- * @package WooCommerce\Tests\Tax
+ * @package ClassicCommerce\Tests\Tax
  */
 class WC_Tests_Tax extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -3,7 +3,7 @@
 /**
  * Test template funcitons.
  *
- * @package WooCommerce/Tests/Templates
+ * @package ClassicCommerce/Tests/Templates
  * @since   3.4.0
  */
 class WC_Tests_Template_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the totals class.
  *
- * @package WooCommerce\Tests\Discounts
+ * @package ClassicCommerce\Tests\Discounts
  */
 
 /**

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests for the core functions.
  *
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since WC-2.2
  */
 

--- a/tests/unit-tests/util/class-wc-tests-user-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-user-functions.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests for the user functions.
  *
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since 3.4.6
  */
 

--- a/tests/unit-tests/util/class-wc-tests-wc-query.php
+++ b/tests/unit-tests/util/class-wc-tests-wc-query.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the WC_Query class.
  *
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since 3.3.0
  */
 

--- a/tests/unit-tests/util/conditional-functions.php
+++ b/tests/unit-tests/util/conditional-functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Conditional_Functions.
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since WC-2.3.0
  */
 class WC_Tests_Conditional_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/util/deprecated-hooks.php
+++ b/tests/unit-tests/util/deprecated-hooks.php
@@ -2,7 +2,7 @@
 
 /**
  * Classes WC_Deprecated_Filter_Hooks & WC_Deprecated_Action_Hooks.
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since 3.0
  */
 class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Tests_Install.
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  */
 class WC_Tests_Install extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/util/notice-functions.php
+++ b/tests/unit-tests/util/notice-functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Notice_Functions.
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since WC-2.2
  */
 class WC_Tests_Notice_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/util/plugin-updates.php
+++ b/tests/unit-tests/util/plugin-updates.php
@@ -2,7 +2,7 @@
 
 /**
  * Class WC_Plugin_Updates.
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since 3.2.0
  */
 class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Validation.
- * @package WooCommerce\Tests\Util
+ * @package ClassicCommerce\Tests\Util
  * @since WC-2.3
  */
 class WC_Tests_Validation extends WC_Unit_Test_Case {

--- a/tests/unit-tests/webhooks/crud.php
+++ b/tests/unit-tests/webhooks/crud.php
@@ -2,7 +2,7 @@
 
 /**
  * Webhook CRUD
- * @package WooCommerce\Tests\CRUD
+ * @package ClassicCommerce\Tests\CRUD
  */
 class WC_Tests_CRUD_Webhooks extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/webhooks/functions.php
+++ b/tests/unit-tests/webhooks/functions.php
@@ -2,7 +2,7 @@
 
 /**
  * Class Functions.
- * @package WooCommerce\Tests\Webhook
+ * @package ClassicCommerce\Tests\Webhook
  * @since WC-2.3
  */
 class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {

--- a/tests/unit-tests/widgets/class-wc-tests-widget.php
+++ b/tests/unit-tests/widgets/class-wc-tests-widget.php
@@ -2,7 +2,7 @@
 /**
  * Testing WC_Widget functionality.
  *
- * @package WooCommerce/Tests/Widgets
+ * @package ClassicCommerce/Tests/Widgets
  */
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Change woocommerce text to cc in tests folder

### Changelog entry
> Change woocommerce text to cc in tests folder
