### PR TITLE
Add PayPal message to Setup wizard page

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1089,7 +1089,7 @@ class WC_Admin_Setup_Wizard {
 				printf(
 					wp_kses(
 						/* translators: %s: Link */
-						__( 'WooCommerce can accept both online and offline payments. <a href="%s" target="_blank">Additional payment methods</a> can be installed later.', 'classic-commerce' ),
+						__( 'WooCommerce can accept both online and offline payments. A basic PayPal option is already included. This can be enabled and configured from the Payments tab under Settings. <a href="%s" target="_blank">Additional payment methods</a> can be installed later.', 'classic-commerce' ),
 						array(
 							'a' => array(
 								'href'   => array(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently the Payments step in the setup wizard only mentions installing additional payments methods. No mention is made of the in-built basic Paypal gateway. It should be made clearer that no further plugins may be required for the user to be able to take online payments. This PR adds two sentences to mention this.

Before:
![previous](https://user-images.githubusercontent.com/46998578/68427710-d24ffd80-01fe-11ea-994d-1adf0526bef1.jpg)

After:
![after](https://user-images.githubusercontent.com/46998578/68427739-ded45600-01fe-11ea-81ab-e0e6b4334b6c.jpg)

### How to test the changes in this Pull Request:

1. Copy the changed text in class-wc-admin-setup-wizard.php to a test site.
2. Run the setup wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Add PayPal message to Setup wizard page to mention in-built PayPal gateway.
