### PR TITLE
Prefix deprecated with WC in abstracts+admin folders

### DIFF
--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -928,7 +928,7 @@ abstract class WC_Settings_API {
 	/**
 	 * Validate the data on the "Settings" form.
 	 *
-	 * @deprecated 2.6.0 No longer used.
+	 * @deprecated WC-2.6.0 No longer used.
 	 * @param array $form_fields Array of fields.
 	 */
 	public function validate_settings_fields( $form_fields = array() ) {
@@ -938,7 +938,7 @@ abstract class WC_Settings_API {
 	/**
 	 * Format settings if needed.
 	 *
-	 * @deprecated 2.6.0 Unused.
+	 * @deprecated WC-2.6.0 Unused.
 	 * @param  array $value Value to format.
 	 * @return array
 	 */

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -120,7 +120,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * Availability - legacy. Used for method Availability.
 	 * No longer useful for instance based shipping methods.
 	 *
-	 * @deprecated 2.6.0
+	 * @deprecated WC-2.6.0
 	 * @var string
 	 */
 	public $availability;
@@ -129,7 +129,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * Availability countries - legacy. Used for method Availability.
 	 * No longer useful for instance based shipping methods.
 	 *
-	 * @deprecated 2.6.0
+	 * @deprecated WC-2.6.0
 	 * @var array
 	 */
 	public $countries = array();

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -65,7 +65,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_style( 'woocommerce_admin_print_reports_styles' );
 			}
 
-			// @deprecated 2.3.
+			// @deprecated WC-2.3.
 			if ( has_action( 'woocommerce_admin_css' ) ) {
 				do_action( 'woocommerce_admin_css' );
 				wc_deprecated_function( 'The woocommerce_admin_css action', '2.3', 'admin_enqueue_scripts' );

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -232,8 +232,8 @@ class WC_Admin_Attributes {
 												/**
 												 * Deprecated action in favor of product_attributes_type_selector filter.
 												 *
-												 * @todo Remove in 4.0.0
-												 * @deprecated 2.4.0
+												 * @todo       Remove in 4.0.0
+												 * @deprecated WC-2.4.0
 												 */
 												do_action( 'woocommerce_admin_attribute_types' );
 											?>
@@ -421,8 +421,8 @@ class WC_Admin_Attributes {
 												/**
 												 * Deprecated action in favor of product_attributes_type_selector filter.
 												 *
-												 * @todo Remove in 4.0.0
-												 * @deprecated 2.4.0
+												 * @todo       Remove in 4.0.0
+												 * @deprecated WC-2.4.0
 												 */
 												do_action( 'woocommerce_admin_attribute_types' );
 											?>

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -192,10 +192,10 @@ class WC_Admin_Duplicate_Product {
 	/**
 	 * Get a product from the database to duplicate.
 	 *
-	 * @deprecated 3.0.0
-	 * @param mixed $id
-	 * @return object|bool
-	 * @see duplicate_product
+	 * @deprecated WC-3.0.0
+	 * @param      mixed $id
+	 * @return     object|bool
+	 * @see        duplicate_product
 	 */
 	private function get_product_to_duplicate( $id ) {
 		global $wpdb;

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -795,7 +795,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				/**
 				 * Fire an action when a certain 'type' of field is being saved.
 				 *
-				 * @deprecated 2.4.0 - doesn't allow manipulation of values!
+				 * @deprecated WC-2.4.0 - doesn't allow manipulation of values!
 				 */
 				if ( has_action( 'woocommerce_update_option_' . sanitize_title( $option['type'] ) ) ) {
 					wc_deprecated_function( 'The woocommerce_update_option_X action', '2.4.0', 'woocommerce_admin_settings_sanitize_option filter' );
@@ -839,7 +839,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				/**
 				 * Fire an action before saved.
 				 *
-				 * @deprecated 2.4.0 - doesn't allow manipulation of values!
+				 * @deprecated WC-2.4.0 - doesn't allow manipulation of values!
 				 */
 				do_action( 'woocommerce_update_option', $option );
 			}

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -297,8 +297,8 @@ class WC_Admin_Webhooks {
 	/**
 	 * Logs output.
 	 *
-	 * @deprecated 3.3.0
-	 * @param WC_Webhook $webhook Deprecated.
+	 * @deprecated WC-3.3.0
+	 * @param      WC_Webhook $webhook Deprecated.
 	 */
 	public static function logs_output( $webhook = 'deprecated' ) {
 		wc_deprecated_function( 'WC_Admin_Webhooks::logs_output', '3.3' );
@@ -336,9 +336,9 @@ class WC_Admin_Webhooks {
 	/**
 	 * Get the logs navigation.
 	 *
-	 * @deprecated 3.3.0
-	 * @param int        $total Deprecated.
-	 * @param WC_Webhook $webhook Deprecated.
+	 * @deprecated WC-3.3.0
+	 * @param      int        $total Deprecated.
+	 * @param      WC_Webhook $webhook Deprecated.
 	 */
 	public static function get_logs_navigation( $total, $webhook ) {
 		wc_deprecated_function( 'WC_Admin_Webhooks::get_logs_navigation', '3.3' );

--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -328,9 +328,9 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 	/**
 	 * Form method.
 	 *
-	 * @deprecated 3.4.4
-	 * @param  string $method Method name.
-	 * @return string
+	 * @deprecated WC-3.4.4
+	 * @param      string $method Method name.
+	 * @return     string
 	 */
 	public function form_method( $method ) {
 		return 'post';
@@ -390,8 +390,8 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 /**
  * WC_Settings_Rest_API class.
  *
- * @deprecated 3.4 in favour of WC_Settings_Advanced.
- * @todo remove in 4.0.
+ * @deprecated WC-3.4 in favour of WC_Settings_Advanced.
+ * @todo       remove in 4.0.
  */
 class WC_Settings_Rest_API extends WC_Settings_Advanced {} // @codingStandardsIgnoreLine.
 

--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -2,8 +2,8 @@
 /**
  * Settings class file.
  *
- * @deprecated 3.4.0 Replaced with class-wc-settings-payment-gateways.php.
- * @todo remove in 4.0.
+ * @deprecated WC-3.4.0 Replaced with class-wc-settings-payment-gateways.php.
+ * @todo       remove in 4.0.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/settings/views/class-wc-settings-rest-api.php
+++ b/includes/admin/settings/views/class-wc-settings-rest-api.php
@@ -2,8 +2,8 @@
 /**
  * Settings class file.
  *
- * @deprecated 3.4.0 Replaced with class-wc-settings-advanced.php.
- * @todo remove in 4.0.
+ * @deprecated WC-3.4.0 Replaced with class-wc-settings-advanced.php.
+ * @todo       remove in 4.0.
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prefix deprecated with WC in includes>abstracts and includes>admin folders.

### How to test the changes in this Pull Request:

1. Check out changes in files in PR

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

Prefix deprecated with WC in includes>abstracts and includes>admin folders.
