### PR TITLE
Prefix deprecated with WC in api to emails folders

### DIFF
--- a/includes/api/legacy/class-wc-rest-legacy-coupons-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-coupons-controller.php
@@ -25,7 +25,7 @@ class WC_REST_Legacy_Coupons_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Query args.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param array $args Query args
 	 * @param WP_REST_Request $request Request data.
@@ -43,7 +43,7 @@ class WC_REST_Legacy_Coupons_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Prepare a single coupon output for response.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param WP_Post $post Post object.
 	 * @param WP_REST_Request $request Request object.
@@ -94,7 +94,7 @@ class WC_REST_Legacy_Coupons_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Prepare a single coupon for create or update.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_Error|stdClass $data Post object.

--- a/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
@@ -32,7 +32,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Query args.
 	 *
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 *
 	 * @param array $args
 	 * @param WP_REST_Request $request
@@ -91,7 +91,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Prepare a single order output for response.
 	 *
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 *
 	 * @param WP_Post $post Post object.
 	 * @param WP_REST_Request $request Request object.
@@ -157,7 +157,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Prepare a single order for create.
 	 *
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 *
 	 * @param  WP_REST_Request $request Request object.
 	 * @return WP_Error|WC_Order $data Object.
@@ -225,7 +225,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Create base WC Order object.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param array $data
 	 * @return WC_Order
@@ -237,7 +237,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Create order.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return int|WP_Error
@@ -276,7 +276,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Update order.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return int|WP_Error

--- a/includes/api/legacy/class-wc-rest-legacy-products-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-products-controller.php
@@ -32,7 +32,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Query args.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param array           $args    Request args.
 	 * @param WP_REST_Request $request Request data.
@@ -153,7 +153,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Prepare a single product output for response.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param WP_Post         $post    Post object.
 	 * @param WP_REST_Request $request Request object.
@@ -198,9 +198,9 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Get product menu order.
 	 *
-	 * @deprecated 3.0.0
-	 * @param WC_Product $product Product instance.
-	 * @return int
+	 * @deprecated WC-3.0.0
+	 * @param      WC_Product $product Product instance.
+	 * @return     int
 	 */
 	protected function get_product_menu_order( $product ) {
 		return $product->get_menu_order();
@@ -209,11 +209,11 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Save product meta.
 	 *
-	 * @deprecated 3.0.0
-	 * @param WC_Product $product
-	 * @param WP_REST_Request $request
-	 * @return bool
-	 * @throws WC_REST_Exception
+	 * @deprecated WC-3.0.0
+	 * @param      WC_Product $product
+	 * @param      WP_REST_Request $request
+	 * @return     bool
+	 * @throws     WC_REST_Exception
 	 */
 	protected function save_product_meta( $product, $request ) {
 		$product = $this->set_product_meta( $product, $request );
@@ -225,7 +225,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Set product meta.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @throws WC_REST_Exception REST API exceptions.
 	 * @param WC_Product      $product Product instance.
@@ -515,7 +515,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Save variations.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @throws WC_REST_Exception REST API exceptions.
 	 * @param WC_Product      $product          Product instance.
@@ -701,7 +701,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Add post meta fields.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param WP_Post         $post    Post data.
 	 * @param WP_REST_Request $request Request data.
@@ -749,7 +749,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Delete post.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param int|WP_Post $id Post ID or WP_Post instance.
 	 */
@@ -779,7 +779,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Get post types.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @return array
 	 */
@@ -790,7 +790,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Save product images.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param int $product_id
 	 * @param array $images

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -2236,14 +2236,14 @@ class WC_API_Products extends WC_API_Resource {
 	/**
 	 * Get product by SKU
 	 *
-	 * @deprecated 2.4.0
+	 * @deprecated WC-2.4.0
 	 *
-	 * @since  WC-2.3.0
+	 * @since      WC-2.3.0
 	 *
-	 * @param  int    $sku the product SKU
-	 * @param  string $fields
+	 * @param      int    $sku the product SKU
+	 * @param      string $fields
 	 *
-	 * @return array|WP_Error
+	 * @return     array|WP_Error
 	 */
 	public function get_product_by_sku( $sku, $fields = null ) {
 		try {

--- a/includes/api/legacy/v2/class-wc-api-webhooks.php
+++ b/includes/api/legacy/v2/class-wc-api-webhooks.php
@@ -410,11 +410,11 @@ class WC_API_Webhooks extends WC_API_Resource {
 	/**
 	 * Get deliveries for a webhook
 	 *
-	 * @since WC-2.2
-	 * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
-	 * @param string $webhook_id webhook ID
-	 * @param string|null $fields fields to include in response
-	 * @return array|WP_Error
+	 * @since      WC-2.2
+	 * @deprecated WC-3.3.0 Webhooks deliveries logs now uses logging system.
+	 * @param      string $webhook_id webhook ID
+	 * @param      string|null $fields fields to include in response
+	 * @return     array|WP_Error
 	 */
 	public function get_webhook_deliveries( $webhook_id, $fields = null ) {
 
@@ -431,13 +431,13 @@ class WC_API_Webhooks extends WC_API_Resource {
 	/**
 	 * Get the delivery log for the given webhook ID and delivery ID
 	 *
-	 * @since WC-2.2
-	 * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
-	 * @param string $webhook_id webhook ID
-	 * @param string $id delivery log ID
-	 * @param string|null $fields fields to limit response to
+	 * @since      WC-2.2
+	 * @deprecated WC-3.3.0 Webhooks deliveries logs now uses logging system.
+	 * @param      string $webhook_id webhook ID
+	 * @param      string $id delivery log ID
+	 * @param      string|null $fields fields to limit response to
 	 *
-	 * @return array|WP_Error
+	 * @return     array|WP_Error
 	 */
 	public function get_webhook_delivery( $webhook_id, $id, $fields = null ) {
 		try {

--- a/includes/api/legacy/v3/class-wc-api-webhooks.php
+++ b/includes/api/legacy/v3/class-wc-api-webhooks.php
@@ -410,11 +410,11 @@ class WC_API_Webhooks extends WC_API_Resource {
 	/**
 	 * Get deliveries for a webhook
 	 *
-	 * @since WC-2.2
-	 * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
-	 * @param string $webhook_id webhook ID
-	 * @param string|null $fields fields to include in response
-	 * @return array|WP_Error
+	 * @since      WC-2.2
+	 * @deprecated WC-3.3.0 Webhooks deliveries logs now uses logging system.
+	 * @param      string $webhook_id webhook ID
+	 * @param      string|null $fields fields to include in response
+	 * @return     array|WP_Error
 	 */
 	public function get_webhook_deliveries( $webhook_id, $fields = null ) {
 
@@ -431,13 +431,13 @@ class WC_API_Webhooks extends WC_API_Resource {
 	/**
 	 * Get the delivery log for the given webhook ID and delivery ID
 	 *
-	 * @since WC-2.2
-	 * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
-	 * @param string $webhook_id webhook ID
-	 * @param string $id delivery log ID
-	 * @param string|null $fields fields to limit response to
+	 * @since      WC-2.2
+	 * @deprecated WC-3.3.0 Webhooks deliveries logs now uses logging system.
+	 * @param      string $webhook_id webhook ID
+	 * @param      string $id delivery log ID
+	 * @param      string|null $fields fields to limit response to
 	 *
-	 * @return array|WP_Error
+	 * @return     array|WP_Error
 	 */
 	public function get_webhook_delivery( $webhook_id, $id, $fields = null ) {
 		try {

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -504,9 +504,9 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 
 	/**
 	 * Create base WC Order object.
-	 * @deprecated 3.0.0
-	 * @param array $data
-	 * @return WC_Order
+	 * @deprecated WC-3.0.0
+	 * @param      array $data
+	 * @return     WC_Order
 	 */
 	protected function create_base_order( $data ) {
 		return wc_create_order( $data );

--- a/includes/api/v1/class-wc-rest-product-attributes-controller.php
+++ b/includes/api/v1/class-wc-rest-product-attributes-controller.php
@@ -557,10 +557,10 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	/**
 	 * Validate attribute slug.
 	 *
-	 * @deprecated 3.2.0
-	 * @param string $slug
-	 * @param bool $new_data
-	 * @return bool|WP_Error
+	 * @deprecated WC-3.2.0
+	 * @param      string $slug
+	 * @param      bool $new_data
+	 * @return     bool|WP_Error
 	 */
 	protected function validate_attribute_slug( $slug, $new_data = true ) {
 		if ( strlen( $slug ) >= 28 ) {
@@ -577,8 +577,8 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	/**
 	 * Schedule to flush rewrite rules.
 	 *
-	 * @deprecated 3.2.0
-	 * @since WC-3.0.0
+	 * @deprecated WC-3.2.0
+	 * @since      WC-3.0.0
 	 */
 	protected function flush_rewrite_rules() {
 		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );

--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -443,9 +443,9 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	/**
 	 * Get product menu order.
 	 *
-	 * @deprecated 3.0.0
-	 * @param WC_Product $product Product instance.
-	 * @return int
+	 * @deprecated WC-3.0.0
+	 * @param      WC_Product $product Product instance.
+	 * @return     int
 	 */
 	protected function get_product_menu_order( $product ) {
 		return $product->get_menu_order();
@@ -823,10 +823,10 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	/**
 	 * Save product images.
 	 *
-	 * @deprecated 3.0.0
-	 * @param int $product_id
-	 * @param array $images
-	 * @throws WC_REST_Exception
+	 * @deprecated WC-3.0.0
+	 * @param      int $product_id
+	 * @param      array $images
+	 * @throws     WC_REST_Exception
 	 */
 	protected function save_product_images( $product_id, $images ) {
 		$product = wc_get_product( $product_id );
@@ -1053,11 +1053,11 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	/**
 	 * Save product meta.
 	 *
-	 * @deprecated 3.0.0
-	 * @param WC_Product $product
-	 * @param WP_REST_Request $request
-	 * @return bool
-	 * @throws WC_REST_Exception
+	 * @deprecated WC-3.0.0
+	 * @param      WC_Product $product
+	 * @param      WP_REST_Request $request
+	 * @return     bool
+	 * @throws     WC_REST_Exception
 	 */
 	protected function save_product_meta( $product, $request ) {
 		$product = $this->set_product_meta( $product, $request );

--- a/includes/api/v1/class-wc-rest-webhook-deliveries-controller.php
+++ b/includes/api/v1/class-wc-rest-webhook-deliveries-controller.php
@@ -17,9 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Webhook Deliveries controller class.
  *
- * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
- * @package ClassicCommerce/API
- * @extends WC_REST_Controller
+ * @deprecated WC-3.3.0 Webhooks deliveries logs now uses logging system.
+ * @package    ClassicCommerce/API
+ * @extends    WC_REST_Controller
  */
 class WC_REST_Webhook_Deliveries_V1_Controller extends WC_REST_Controller {
 

--- a/includes/api/v2/class-wc-rest-products-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-products-v2-controller.php
@@ -420,7 +420,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Get attribute taxonomy label.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param  string $name Taxonomy name.
 	 * @return string

--- a/includes/api/v2/class-wc-rest-webhook-deliveries-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-webhook-deliveries-v2-controller.php
@@ -13,9 +13,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Webhook Deliveries controller class.
  *
- * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
- * @package ClassicCommerce/API
- * @extends WC_REST_Webhook_Deliveries_V1_Controller
+ * @deprecated WC-3.3.0 Webhooks deliveries logs now uses logging system.
+ * @package    ClassicCommerce/API
+ * @extends    WC_REST_Webhook_Deliveries_V1_Controller
  */
 class WC_REST_Webhook_Deliveries_V2_Controller extends WC_REST_Webhook_Deliveries_V1_Controller {
 

--- a/includes/data-stores/class-wc-customer-download-data-store.php
+++ b/includes/data-stores/class-wc-customer-download-data-store.php
@@ -361,7 +361,7 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 	/**
 	 * Update download ids if the hash changes.
 	 *
-	 * @deprecated 3.3.0 Download id is now a static UUID and should not be changed based on file hash.
+	 * @deprecated WC-3.3.0 Download id is now a static UUID and should not be changed based on file hash.
 	 *
 	 * @param  int    $product_id Product ID.
 	 * @param  string $old_id Old download_id.

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -378,8 +378,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	/**
 	 * Get all orders matching the passed in args.
 	 *
-	 * @deprecated 3.1.0 - Use wc_get_orders instead.
-	 * @see    wc_get_orders()
+	 * @deprecated WC-3.1.0 - Use wc_get_orders instead.
+	 * @see        wc_get_orders()
 	 *
 	 * @param  array $args List of args passed to wc_get_orders().
 	 *

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -122,8 +122,8 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Set email strings.
 		 *
-		 * @param bool $partial_refund Whether it is a partial refund or a full refund.
-		 * @deprecated 3.1.0 Unused.
+		 * @param      bool $partial_refund Whether it is a partial refund or a full refund.
+		 * @deprecated WC-3.1.0 Unused.
 		 */
 		public function set_email_strings( $partial_refund = false ) {}
 

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -211,16 +211,16 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Strings to find in subjects/headings.
 	 *
-	 * @deprecated 3.2.0 in favour of placeholders
-	 * @var array
+	 * @deprecated WC-3.2.0 in favour of placeholders
+	 * @var        array
 	 */
 	public $find = array();
 
 	/**
 	 * Strings to replace in subjects/headings.
 	 *
-	 * @deprecated 3.2.0 in favour of placeholders
-	 * @var array
+	 * @deprecated WC-3.2.0 in favour of placeholders
+	 * @var        array
 	 */
 	public $replace = array();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prefix deprecated with WC in includes>api to includes>emails folders.

### How to test the changes in this Pull Request:

1. Check out changes in files in PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

Prefix deprecated with WC in includes>api to includes>emails folders.
