### PR TITLE
Prefix deprecated with WC in export to queue folders

### DIFF
--- a/includes/legacy/abstract-wc-legacy-order.php
+++ b/includes/legacy/abstract-wc-legacy-order.php
@@ -559,8 +559,8 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Gets shipping total. Alias of WC_Order::get_shipping_total().
-	 * @deprecated 3.0.0 since this is an alias only.
-	 * @return float
+	 * @deprecated WC-3.0.0 since this is an alias only.
+	 * @return     float
 	 */
 	public function get_total_shipping() {
 		return $this->get_shipping_total();
@@ -568,11 +568,11 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Get order item meta.
-	 * @deprecated 3.0.0
-	 * @param mixed $order_item_id
-	 * @param string $key (default: '')
-	 * @param bool $single (default: false)
-	 * @return array|string
+	 * @deprecated WC-3.0.0
+	 * @param      mixed $order_item_id
+	 * @param      string $key (default: '')
+	 * @param      bool $single (default: false)
+	 * @return     array|string
 	 */
 	public function get_item_meta( $order_item_id, $key = '', $single = false ) {
 		wc_deprecated_function( 'WC_Order::get_item_meta', '3.0', 'wc_get_order_item_meta' );
@@ -600,7 +600,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Expand item meta into the $item array.
-	 * @deprecated 3.0.0 Item meta no longer expanded due to new order item
+	 * @deprecated WC-3.0.0 Item meta no longer expanded due to new order item
 	 *		classes. This function now does nothing to avoid data breakage.
 	 * @param array $item before expansion.
 	 * @return array
@@ -612,7 +612,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Load the order object. Called from the constructor.
-	 * @deprecated 3.0.0 Logic moved to constructor
+	 * @deprecated WC-3.0.0 Logic moved to constructor
 	 * @param int|object|WC_Order $order Order to init.
 	 */
 	protected function init( $order ) {
@@ -630,9 +630,9 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Gets an order from the database.
-	 * @deprecated 3.0
-	 * @param int $id (default: 0).
-	 * @return bool
+	 * @deprecated WC-3.0
+	 * @param      int $id (default: 0).
+	 * @return     bool
 	 */
 	public function get_order( $id = 0 ) {
 		wc_deprecated_function( 'WC_Order::get_order', '3.0' );
@@ -653,8 +653,8 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Populates an order from the loaded post data.
-	 * @deprecated 3.0
-	 * @param mixed $result
+	 * @deprecated WC-3.0
+	 * @param      mixed $result
 	 */
 	public function populate( $result ) {
 		wc_deprecated_function( 'WC_Order::populate', '3.0' );
@@ -665,8 +665,8 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Cancel the order and restore the cart (before payment).
-	 * @deprecated 3.0.0 Moved to event handler.
-	 * @param string $note (default: '') Optional note to add.
+	 * @deprecated WC-3.0.0 Moved to event handler.
+	 * @param      string $note (default: '') Optional note to add.
 	 */
 	public function cancel_order( $note = '' ) {
 		wc_deprecated_function( 'WC_Order::cancel_order', '3.0', 'WC_Order::update_status' );
@@ -676,7 +676,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Record sales.
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 */
 	public function record_product_sales() {
 		wc_deprecated_function( 'WC_Order::record_product_sales', '3.0', 'wc_update_total_sales_counts' );
@@ -685,7 +685,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Increase applied coupon counts.
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 */
 	public function increase_coupon_usage_counts() {
 		wc_deprecated_function( 'WC_Order::increase_coupon_usage_counts', '3.0', 'wc_update_coupon_usage_counts' );
@@ -694,7 +694,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Decrease applied coupon counts.
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 */
 	public function decrease_coupon_usage_counts() {
 		wc_deprecated_function( 'WC_Order::decrease_coupon_usage_counts', '3.0', 'wc_update_coupon_usage_counts' );
@@ -703,7 +703,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Reduce stock levels for all line items in the order.
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 */
 	public function reduce_order_stock() {
 		wc_deprecated_function( 'WC_Order::reduce_order_stock', '3.0', 'wc_reduce_stock_levels' );
@@ -712,7 +712,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Send the stock notifications.
-	 * @deprecated 3.0.0 No longer needs to be called directly.
+	 * @deprecated WC-3.0.0 No longer needs to be called directly.
 	 *
 	 * @param $product
 	 * @param $new_stock
@@ -724,9 +724,9 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Output items for display in html emails.
-	 * @deprecated 3.0.0 Moved to template functions.
-	 * @param array $args Items args.
-	 * @return string
+	 * @deprecated WC-3.0.0 Moved to template functions.
+	 * @param      array $args Items args.
+	 * @return     string
 	 */
 	public function email_order_items_table( $args = array() ) {
 		wc_deprecated_function( 'WC_Order::email_order_items_table', '3.0', 'wc_get_email_order_items' );
@@ -735,7 +735,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Get currency.
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 */
 	public function get_order_currency() {
 		wc_deprecated_function( 'WC_Order::get_order_currency', '3.0', 'WC_Order::get_currency' );

--- a/includes/legacy/abstract-wc-legacy-payment-token.php
+++ b/includes/legacy/abstract-wc-legacy-payment-token.php
@@ -28,7 +28,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 
 	/**
 	 * Read a token by ID.
-	 * @deprecated 3.0.0 - Init a token class with an ID.
+	 * @deprecated WC-3.0.0 - Init a token class with an ID.
 	 *
 	 * @param int $token_id
 	 */
@@ -41,7 +41,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 
 	/**
 	 * Update a token.
-	 * @deprecated 3.0.0 - Use ::save instead.
+	 * @deprecated WC-3.0.0 - Use ::save instead.
 	 */
 	public function update() {
 		wc_deprecated_function( 'WC_Payment_Token::update', '3.0.0', 'WC_Payment_Token::save instead.' );
@@ -55,7 +55,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 
 	/**
 	 * Create a token.
-	 * @deprecated 3.0.0 - Use ::save instead.
+	 * @deprecated WC-3.0.0 - Use ::save instead.
 	 */
 	public function create() {
 		wc_deprecated_function( 'WC_Payment_Token::create', '3.0.0', 'WC_Payment_Token::save instead.' );

--- a/includes/legacy/abstract-wc-legacy-product.php
+++ b/includes/legacy/abstract-wc-legacy-product.php
@@ -141,7 +141,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 			case 'variation_has_weight' :
 			case 'variation_has_tax_class' :
 			case 'variation_has_downloadable_files' :
-				$value = true; // These were deprecated in 2.2 and simply returned true in 2.6.x.
+				$value = true; // These were deprecated in WC-2.2 and simply returned true in WC-2.6.x.
 				break;
 			default :
 				if ( in_array( $key, array_keys( $this->data ) ) ) {
@@ -157,8 +157,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * If set, get the default attributes for a variable product.
 	 *
-	 * @deprecated 3.0.0
-	 * @return array
+	 * @deprecated WC-3.0.0
+	 * @return     array
 	 */
 	public function get_variation_default_attributes() {
 		wc_deprecated_function( 'WC_Product_Variable::get_variation_default_attributes', '3.0', 'WC_Product::get_default_attributes' );
@@ -168,8 +168,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the gallery attachment ids.
 	 *
-	 * @deprecated 3.0.0
-	 * @return array
+	 * @deprecated WC-3.0.0
+	 * @return     array
 	 */
 	public function get_gallery_attachment_ids() {
 		wc_deprecated_function( 'WC_Product::get_gallery_attachment_ids', '3.0', 'WC_Product::get_gallery_image_ids' );
@@ -179,7 +179,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Set stock level of the product.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param int $amount
 	 * @param string $mode
@@ -194,9 +194,9 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Reduce stock level of the product.
 	 *
-	 * @deprecated 3.0.0
-	 * @param int $amount Amount to reduce by. Default: 1
-	 * @return int new stock level
+	 * @deprecated WC-3.0.0
+	 * @param      int $amount Amount to reduce by. Default: 1
+	 * @return     int new stock level
 	 */
 	public function reduce_stock( $amount = 1 ) {
 		wc_deprecated_function( 'WC_Product::reduce_stock', '3.0', 'wc_update_product_stock' );
@@ -206,9 +206,9 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Increase stock level of the product.
 	 *
-	 * @deprecated 3.0.0
-	 * @param int $amount Amount to increase by. Default 1.
-	 * @return int new stock level
+	 * @deprecated WC-3.0.0
+	 * @param      int $amount Amount to increase by. Default 1.
+	 * @return     int new stock level
 	 */
 	public function increase_stock( $amount = 1 ) {
 		wc_deprecated_function( 'WC_Product::increase_stock', '3.0', 'wc_update_product_stock' );
@@ -218,7 +218,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Check if the stock status needs changing.
 	 *
-	 * @deprecated 3.0.0 Sync is done automatically on read/save, so calling this should not be needed any more.
+	 * @deprecated WC-3.0.0 Sync is done automatically on read/save, so calling this should not be needed any more.
 	 */
 	public function check_stock_status() {
 		wc_deprecated_function( 'WC_Product::check_stock_status', '3.0' );
@@ -226,7 +226,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Get and return related products.
-	 * @deprecated 3.0.0 Use wc_get_related_products instead.
+	 * @deprecated WC-3.0.0 Use wc_get_related_products instead.
 	 *
 	 * @param int $limit
 	 *
@@ -239,7 +239,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Retrieves related product terms.
-	 * @deprecated 3.0.0 Use wc_get_product_term_ids instead.
+	 * @deprecated WC-3.0.0 Use wc_get_product_term_ids instead.
 	 *
 	 * @param $term
 	 *
@@ -252,7 +252,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Builds the related posts query.
-	 * @deprecated 3.0.0 Use Product Data Store get_related_products_query instead.
+	 * @deprecated WC-3.0.0 Use Product Data Store get_related_products_query instead.
 	 *
 	 * @param $cats_array
 	 * @param $tags_array
@@ -267,9 +267,9 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Returns the child product.
-	 * @deprecated 3.0.0 Use wc_get_product instead.
-	 * @param mixed $child_id
-	 * @return WC_Product|WC_Product|WC_Product_variation
+	 * @deprecated WC-3.0.0 Use wc_get_product instead.
+	 * @param      mixed $child_id
+	 * @return     WC_Product|WC_Product|WC_Product_variation
 	 */
 	public function get_child( $child_id ) {
 		wc_deprecated_function( 'WC_Product::get_child', '3.0', 'wc_get_product' );
@@ -279,8 +279,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Functions for getting parts of a price, in html, used by get_price_html.
 	 *
-	 * @deprecated 3.0.0
-	 * @return string
+	 * @deprecated WC-3.0.0
+	 * @return     string
 	 */
 	public function get_price_html_from_text() {
 		wc_deprecated_function( 'WC_Product::get_price_html_from_text', '3.0', 'wc_get_price_html_from_text' );
@@ -290,10 +290,10 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Functions for getting parts of a price, in html, used by get_price_html.
 	 *
-	 * @deprecated 3.0.0 Use wc_format_sale_price instead.
-	 * @param  string $from String or float to wrap with 'from' text
-	 * @param  mixed $to String or float to wrap with 'to' text
-	 * @return string
+	 * @deprecated WC-3.0.0 Use wc_format_sale_price instead.
+	 * @param      string $from String or float to wrap with 'from' text
+	 * @param      mixed $to String or float to wrap with 'to' text
+	 * @return     string
 	 */
 	public function get_price_html_from_to( $from, $to ) {
 		wc_deprecated_function( 'WC_Product::get_price_html_from_to', '3.0', 'wc_format_sale_price' );
@@ -302,7 +302,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Lists a table of attributes for the product page.
-	 * @deprecated 3.0.0 Use wc_display_product_attributes instead.
+	 * @deprecated WC-3.0.0 Use wc_display_product_attributes instead.
 	 */
 	public function list_attributes() {
 		wc_deprecated_function( 'WC_Product::list_attributes', '3.0', 'wc_display_product_attributes' );
@@ -312,10 +312,10 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the price (including tax). Uses customer tax rates. Can work for a specific $qty for more accurate taxes.
 	 *
-	 * @deprecated 3.0.0 Use wc_get_price_including_tax instead.
-	 * @param  int $qty
-	 * @param  string $price to calculate, left blank to just use get_price()
-	 * @return string
+	 * @deprecated WC-3.0.0 Use wc_get_price_including_tax instead.
+	 * @param      int $qty
+	 * @param      string $price to calculate, left blank to just use get_price()
+	 * @return     string
 	 */
 	public function get_price_including_tax( $qty = 1, $price = '' ) {
 		wc_deprecated_function( 'WC_Product::get_price_including_tax', '3.0', 'wc_get_price_including_tax' );
@@ -325,10 +325,10 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the price including or excluding tax, based on the 'woocommerce_tax_display_shop' setting.
 	 *
-	 * @deprecated 3.0.0 Use wc_get_price_to_display instead.
-	 * @param  string  $price to calculate, left blank to just use get_price()
-	 * @param  integer $qty   passed on to get_price_including_tax() or get_price_excluding_tax()
-	 * @return string
+	 * @deprecated WC-3.0.0 Use wc_get_price_to_display instead.
+	 * @param      string  $price to calculate, left blank to just use get_price()
+	 * @param      integer $qty   passed on to get_price_including_tax() or get_price_excluding_tax()
+	 * @return     string
 	 */
 	public function get_display_price( $price = '', $qty = 1 ) {
 		wc_deprecated_function( 'WC_Product::get_display_price', '3.0', 'wc_get_price_to_display' );
@@ -339,10 +339,10 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * Returns the price (excluding tax) - ignores tax_class filters since the price may *include* tax and thus needs subtracting.
 	 * Uses store base tax rates. Can work for a specific $qty for more accurate taxes.
 	 *
-	 * @deprecated 3.0.0 Use wc_get_price_excluding_tax instead.
-	 * @param  int $qty
-	 * @param  string $price to calculate, left blank to just use get_price()
-	 * @return string
+	 * @deprecated WC-3.0.0 Use wc_get_price_excluding_tax instead.
+	 * @param      int $qty
+	 * @param      string $price to calculate, left blank to just use get_price()
+	 * @return     string
 	 */
 	public function get_price_excluding_tax( $qty = 1, $price = '' ) {
 		wc_deprecated_function( 'WC_Product::get_price_excluding_tax', '3.0', 'wc_get_price_excluding_tax' );
@@ -352,8 +352,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Adjust a products price dynamically.
 	 *
-	 * @deprecated 3.0.0
-	 * @param mixed $price
+	 * @deprecated WC-3.0.0
+	 * @param      mixed $price
 	 */
 	public function adjust_price( $price ) {
 		wc_deprecated_function( 'WC_Product::adjust_price', '3.0', 'WC_Product::set_price / WC_Product::get_price' );
@@ -363,11 +363,11 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the product categories.
 	 *
-	 * @deprecated 3.0.0
-	 * @param string $sep (default: ', ').
-	 * @param string $before (default: '').
-	 * @param string $after (default: '').
-	 * @return string
+	 * @deprecated WC-3.0.0
+	 * @param      string $sep (default: ', ').
+	 * @param      string $before (default: '').
+	 * @param      string $after (default: '').
+	 * @return     string
 	 */
 	public function get_categories( $sep = ', ', $before = '', $after = '' ) {
 		wc_deprecated_function( 'WC_Product::get_categories', '3.0', 'wc_get_product_category_list' );
@@ -377,11 +377,11 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the product tags.
 	 *
-	 * @deprecated 3.0.0
-	 * @param string $sep (default: ', ').
-	 * @param string $before (default: '').
-	 * @param string $after (default: '').
-	 * @return array
+	 * @deprecated WC-3.0.0
+	 * @param      string $sep (default: ', ').
+	 * @param      string $before (default: '').
+	 * @param      string $after (default: '').
+	 * @return     array
 	 */
 	public function get_tags( $sep = ', ', $before = '', $after = '' ) {
 		wc_deprecated_function( 'WC_Product::get_tags', '3.0', 'wc_get_product_tag_list' );
@@ -391,8 +391,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Get the product's post data.
 	 *
-	 * @deprecated 3.0.0
-	 * @return WP_Post
+	 * @deprecated WC-3.0.0
+	 * @return     WP_Post
 	 */
 	public function get_post_data() {
 		wc_deprecated_function( 'WC_Product::get_post_data', '3.0', 'get_post' );
@@ -410,8 +410,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Get the parent of the post.
 	 *
-	 * @deprecated 3.0.0
-	 * @return int
+	 * @deprecated WC-3.0.0
+	 * @return     int
 	 */
 	public function get_parent() {
 		wc_deprecated_function( 'WC_Product::get_parent', '3.0', 'WC_Product::get_parent_id' );
@@ -421,8 +421,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the upsell product ids.
 	 *
-	 * @deprecated 3.0.0
-	 * @return array
+	 * @deprecated WC-3.0.0
+	 * @return     array
 	 */
 	public function get_upsells() {
 		wc_deprecated_function( 'WC_Product::get_upsells', '3.0', 'WC_Product::get_upsell_ids' );
@@ -432,8 +432,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the cross sell product ids.
 	 *
-	 * @deprecated 3.0.0
-	 * @return array
+	 * @deprecated WC-3.0.0
+	 * @return     array
 	 */
 	public function get_cross_sells() {
 		wc_deprecated_function( 'WC_Product::get_cross_sells', '3.0', 'WC_Product::get_cross_sell_ids' );
@@ -443,8 +443,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Check if variable product has default attributes set.
 	 *
-	 * @deprecated 3.0.0
-	 * @return bool
+	 * @deprecated WC-3.0.0
+	 * @return     bool
 	 */
 	public function has_default_attributes() {
 		wc_deprecated_function( 'WC_Product_Variable::has_default_attributes', '3.0', 'a check against WC_Product::get_default_attributes directly' );
@@ -457,8 +457,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Get variation ID.
 	 *
-	 * @deprecated 3.0.0
-	 * @return int
+	 * @deprecated WC-3.0.0
+	 * @return     int
 	 */
 	public function get_variation_id() {
 		wc_deprecated_function( 'WC_Product::get_variation_id', '3.0', 'WC_Product::get_id(). It will always be the variation ID if this is a variation.' );
@@ -468,8 +468,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Get product variation description.
 	 *
-	 * @deprecated 3.0.0
-	 * @return string
+	 * @deprecated WC-3.0.0
+	 * @return     string
 	 */
 	public function get_variation_description() {
 		wc_deprecated_function( 'WC_Product::get_variation_description', '3.0', 'WC_Product::get_description()' );
@@ -479,8 +479,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Check if all variation's attributes are set.
 	 *
-	 * @deprecated 3.0.0
-	 * @return boolean
+	 * @deprecated WC-3.0.0
+	 * @return     boolean
 	 */
 	public function has_all_attributes_set() {
 		wc_deprecated_function( 'WC_Product::has_all_attributes_set', '3.0', 'an array filter on get_variation_attributes for a quick solution.' );
@@ -499,8 +499,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns whether or not the variations parent is visible.
 	 *
-	 * @deprecated 3.0.0
-	 * @return bool
+	 * @deprecated WC-3.0.0
+	 * @return     bool
 	 */
 	public function parent_is_visible() {
 		wc_deprecated_function( 'WC_Product::parent_is_visible', '3.0' );
@@ -510,8 +510,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Get total stock - This is the stock of parent and children combined.
 	 *
-	 * @deprecated 3.0.0
-	 * @return int
+	 * @deprecated WC-3.0.0
+	 * @return     int
 	 */
 	public function get_total_stock() {
 		wc_deprecated_function( 'WC_Product::get_total_stock', '3.0', 'get_stock_quantity on each child. Beware of performance issues in doing so.' );
@@ -533,7 +533,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Get formatted variation data with WC < 2.4 back compat and proper formatting of text-based attribute names.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 *
 	 * @param bool $flat
 	 *
@@ -547,7 +547,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Sync variable product prices with the children lowest/highest prices.
 	 *
-	 * @deprecated 3.0.0 not used in core.
+	 * @deprecated WC-3.0.0 not used in core.
 	 *
 	 * @param int $product_id
 	 */
@@ -613,7 +613,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Match a variation to a given set of attributes using a WP_Query.
-	 * @deprecated 3.0.0 in favour of Product data store's find_matching_product_variation.
+	 * @deprecated WC-3.0.0 in favour of Product data store's find_matching_product_variation.
 	 *
 	 * @param array $match_attributes
 	 */
@@ -625,8 +625,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Returns whether or not we are showing dimensions on the product page.
-	 * @deprecated 3.0.0 Unused.
-	 * @return bool
+	 * @deprecated WC-3.0.0 Unused.
+	 * @return     bool
 	 */
 	public function enable_dimensions_display() {
 		wc_deprecated_function( 'WC_Product::enable_dimensions_display', '3.0' );
@@ -636,9 +636,9 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the product rating in html format.
 	 *
-	 * @deprecated 3.0.0
-	 * @param string $rating (default: '')
-	 * @return string
+	 * @deprecated WC-3.0.0
+	 * @param      string $rating (default: '')
+	 * @return     string
 	 */
 	public function get_rating_html( $rating = null ) {
 		wc_deprecated_function( 'WC_Product::get_rating_html', '3.0', 'wc_get_rating_html' );
@@ -648,8 +648,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Sync product rating. Can be called statically.
 	 *
-	 * @deprecated 3.0.0
-	 * @param  int $post_id
+	 * @deprecated WC-3.0.0
+	 * @param      int $post_id
 	 */
 	public static function sync_average_rating( $post_id ) {
 		wc_deprecated_function( 'WC_Product::sync_average_rating', '3.0', 'WC_Comments::get_average_rating_for_product or leave to CRUD.' );
@@ -660,7 +660,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Sync product rating count. Can be called statically.
 	 *
-	 * @deprecated 3.0.0
+	 * @deprecated WC-3.0.0
 	 * @param  int $post_id
 	 */
 	public static function sync_rating_count( $post_id ) {
@@ -672,8 +672,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Same as get_downloads in CRUD.
 	 *
-	 * @deprecated 3.0.0
-	 * @return array
+	 * @deprecated WC-3.0.0
+	 * @return     array
 	 */
 	public function get_files() {
 		wc_deprecated_function( 'WC_Product::get_files', '3.0', 'WC_Product::get_downloads' );
@@ -681,7 +681,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	}
 
 	/**
-	 * @deprecated 3.0.0 Sync is taken care of during save - no need to call this directly.
+	 * @deprecated WC-3.0.0 Sync is taken care of during save - no need to call this directly.
 	 */
 	public function grouped_product_sync() {
 		wc_deprecated_function( 'WC_Product::grouped_product_sync', '3.0' );

--- a/includes/legacy/class-wc-legacy-api.php
+++ b/includes/legacy/class-wc-legacy-api.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ClassicCommerce Legacy API. Was deprecated with 2.6.0.
+ * ClassicCommerce Legacy API. Was deprecated with WC-2.6.0.
  *
  * @author   WooThemes
  * @category API
@@ -21,24 +21,24 @@ class WC_Legacy_API {
 	 * This is the major version for the REST API and takes
 	 * first-order position in endpoint URLs.
 	 *
-	 * @deprecated 2.6.0
-	 * @var string
+	 * @deprecated WC-2.6.0
+	 * @var        string
 	 */
 	const VERSION = '3.1.0';
 
 	/**
 	 * The REST API server.
 	 *
-	 * @deprecated 2.6.0
-	 * @var WC_API_Server
+	 * @deprecated WC-2.6.0
+	 * @var        WC_API_Server
 	 */
 	public $server;
 
 	/**
 	 * REST API authentication class instance.
 	 *
-	 * @deprecated 2.6.0
-	 * @var WC_API_Authentication
+	 * @deprecated WC-2.6.0
+	 * @var        WC_API_Authentication
 	 */
 	public $authentication;
 
@@ -70,7 +70,7 @@ class WC_Legacy_API {
 	 * @since WC-2.0
 	 */
 	public static function add_endpoint() {
-		// REST API, deprecated since 2.6.0.
+		// REST API, deprecated since WC-2.6.0.
 		add_rewrite_rule( '^wc-api/v([1-3]{1})/?$', 'index.php?wc-api-version=$matches[1]&wc-api-route=/', 'top' );
 		add_rewrite_rule( '^wc-api/v([1-3]{1})(.*)?', 'index.php?wc-api-version=$matches[1]&wc-api-route=$matches[2]', 'top' );
 	}
@@ -78,8 +78,8 @@ class WC_Legacy_API {
 	/**
 	 * Handle REST API requests.
 	 *
-	 * @since WC-2.2
-	 * @deprecated 2.6.0
+	 * @since      WC-2.2
+	 * @deprecated WC-2.6.0
 	 */
 	public function handle_rest_api_requests() {
 		global $wp;
@@ -122,8 +122,8 @@ class WC_Legacy_API {
 	/**
 	 * Include required files for REST API request.
 	 *
-	 * @since WC-2.1
-	 * @deprecated 2.6.0
+	 * @since      WC-2.1
+	 * @deprecated WC-2.6.0
 	 */
 	public function includes() {
 
@@ -153,9 +153,9 @@ class WC_Legacy_API {
 	/**
 	 * Register available API resources.
 	 *
-	 * @since WC-2.1
-	 * @deprecated 2.6.0
-	 * @param WC_API_Server $server the REST server.
+	 * @since      WC-2.1
+	 * @deprecated WC-2.6.0
+	 * @param      WC_API_Server $server the REST server.
 	 */
 	public function register_resources( $server ) {
 
@@ -180,8 +180,8 @@ class WC_Legacy_API {
 	/**
 	 * Handle legacy v1 REST API requests.
 	 *
-	 * @since WC-2.2
-	 * @deprecated 2.6.0
+	 * @since      WC-2.2
+	 * @deprecated WC-2.6.0
 	 */
 	private function handle_v1_rest_api_request() {
 
@@ -228,8 +228,8 @@ class WC_Legacy_API {
 	/**
 	 * Handle legacy v2 REST API requests.
 	 *
-	 * @since WC-2.4
-	 * @deprecated 2.6.0
+	 * @since      WC-2.4
+	 * @deprecated WC-2.6.0
 	 */
 	private function handle_v2_rest_api_request() {
 		include_once( dirname( __FILE__ ) . '/../api/legacy/v2/class-wc-api-exception.php' );

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -23,7 +23,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Array of defaults. Not used since 3.2.
 	 *
-	 * @deprecated 3.2.0
+	 * @deprecated WC-3.2.0
 	 */
 	public $cart_session_data = array(
 		'cart_contents_total'         => 0,
@@ -46,7 +46,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Contains an array of coupon usage counts after they have been applied.
 	 *
-	 * @deprecated 3.2.0
+	 * @deprecated WC-3.2.0
 	 * @var array
 	 */
 	public $coupon_applied_count = array();
@@ -269,7 +269,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Remove taxes.
 	 *
-	 * @deprecated 3.2.0 Taxes are never calculated if customer is tax except making this function unused.
+	 * @deprecated WC-3.2.0 Taxes are never calculated if customer is tax except making this function unused.
 	 */
 	public function remove_taxes() {
 		wc_deprecated_function( 'WC_Cart::remove_taxes', '3.2', '' );
@@ -277,7 +277,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Init.
 	 *
-	 * @deprecated 3.2.0 Session is loaded via hooks rather than directly.
+	 * @deprecated WC-3.2.0 Session is loaded via hooks rather than directly.
 	 */
 	public function init() {
 		wc_deprecated_function( 'WC_Cart::init', '3.2', '' );
@@ -305,7 +305,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Gets the url to the cart page.
 	 *
-	 * @deprecated 2.5.0 in favor to wc_get_cart_url()
+	 * @deprecated WC-2.5.0 in favor to wc_get_cart_url()
 	 * @return string url to page
 	 */
 	public function get_cart_url() {
@@ -316,7 +316,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Gets the url to the checkout page.
 	 *
-	 * @deprecated 2.5.0 in favor to wc_get_checkout_url()
+	 * @deprecated WC-2.5.0 in favor to wc_get_checkout_url()
 	 * @return string url to page
 	 */
 	public function get_checkout_url() {
@@ -327,7 +327,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Sees if we need a shipping address.
 	 *
-	 * @deprecated 2.5.0 in favor to wc_ship_to_billing_address_only()
+	 * @deprecated WC-2.5.0 in favor to wc_ship_to_billing_address_only()
 	 * @return bool
 	 */
 	public function ship_to_billing_address_only() {
@@ -338,7 +338,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Coupons enabled function. Filterable.
 	 *
-	 * @deprecated 2.5.0 in favor to wc_coupons_enabled()
+	 * @deprecated WC-2.5.0 in favor to wc_coupons_enabled()
 	 * @return bool
 	 */
 	public function coupons_enabled() {

--- a/includes/legacy/class-wc-legacy-shipping-zone.php
+++ b/includes/legacy/class-wc-legacy-shipping-zone.php
@@ -16,7 +16,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	/**
 	 * Get zone ID
 	 * @return int|null Null if the zone does not exist. 0 is the default zone.
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 */
 	public function get_zone_id() {
 		wc_deprecated_function( 'WC_Shipping_Zone::get_zone_id', '3.0', 'WC_Shipping_Zone::get_id' );
@@ -25,7 +25,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 
 	/**
 	 * Read a shipping zone by ID.
-	 * @deprecated 3.0.0 - Init a shipping zone with an ID.
+	 * @deprecated WC-3.0.0 - Init a shipping zone with an ID.
 	 *
 	 * @param int $zone_id
 	 */
@@ -38,7 +38,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 
 	/**
 	 * Update a zone.
-	 * @deprecated 3.0.0 - Use ::save instead.
+	 * @deprecated WC-3.0.0 - Use ::save instead.
 	 */
 	public function update() {
 		wc_deprecated_function( 'WC_Shipping_Zone::update', '3.0', 'WC_Shipping_Zone::save instead.' );
@@ -52,7 +52,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 
 	/**
 	 * Create a zone.
-	 * @deprecated 3.0.0 - Use ::save instead.
+	 * @deprecated WC-3.0.0 - Use ::save instead.
 	 */
 	public function create() {
 		wc_deprecated_function( 'WC_Shipping_Zone::create', '3.0', 'WC_Shipping_Zone::save instead.' );

--- a/includes/legacy/class-wc-legacy-webhook.php
+++ b/includes/legacy/class-wc-legacy-webhook.php
@@ -103,7 +103,7 @@ abstract class WC_Legacy_Webhook extends WC_Data {
 	/**
 	 * Get the post data for the webhook.
 	 *
-	 * @deprecated 3.2.0
+	 * @deprecated WC-3.2.0
 	 * @since      WC-2.2
 	 * @return     null|WP_Post
 	 */
@@ -116,7 +116,7 @@ abstract class WC_Legacy_Webhook extends WC_Data {
 	/**
 	 * Update the webhook status.
 	 *
-	 * @deprecated 3.2.0
+	 * @deprecated WC-3.2.0
 	 * @since      WC-2.2.0
 	 * @param      string $status Status to set.
 	 */

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_Store.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_Store.php
@@ -202,8 +202,8 @@ abstract class ActionScheduler_Store {
 	/**
 	 * Get the site's local time.
 	 *
-	 * @deprecated 2.1.0
-	 * @return DateTimeZone
+	 * @deprecated WC-2.1.0
+	 * @return     DateTimeZone
 	 */
 	protected function get_local_timezone() {
 		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_TimezoneHelper.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_TimezoneHelper.php
@@ -97,7 +97,7 @@ abstract class ActionScheduler_TimezoneHelper {
 	}
 
 	/**
-	 * @deprecated 2.1.0
+	 * @deprecated WC-2.1.0
 	 */
 	public static function get_local_timezone( $reset = FALSE ) {
 		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );

--- a/includes/libraries/action-scheduler/deprecated/functions.php
+++ b/includes/libraries/action-scheduler/deprecated/functions.php
@@ -32,7 +32,7 @@ function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @param array $args Arguments to pass when the hook triggers
  * @param string $group The group to assign this job to
  *
- * @deprecated 2.1.0
+ * @deprecated WC-2.1.0
  *
  * @return string The job ID
  */
@@ -60,7 +60,7 @@ function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @param array $args Arguments to pass when the hook triggers
  * @param string $group The group to assign this job to
  *
- * @deprecated 2.1.0
+ * @deprecated WC-2.1.0
  *
  * @return string The job ID
  */
@@ -76,7 +76,7 @@ function wc_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
  * @param array $args Args that would have been passed to the job
  * @param string $group
  *
- * @deprecated 2.1.0
+ * @deprecated WC-2.1.0
  */
 function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
 	_deprecated_function( __FUNCTION__, '2.1.0', 'as_unschedule_action()' );
@@ -88,7 +88,7 @@ function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
  * @param array $args
  * @param string $group
  *
- * @deprecated 2.1.0
+ * @deprecated WC-2.1.0
  *
  * @return int|bool The timestamp for the next occurrence, or false if nothing was found
  */
@@ -116,7 +116,7 @@ function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
  *        'order' => 'ASC'
  * @param string $return_format OBJECT, ARRAY_A, or ids
  *
- * @deprecated 2.1.0
+ * @deprecated WC-2.1.0
  *
  * @return array
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prefix deprecated with WC in includes>export to includes>queue folders.

### How to test the changes in this Pull Request:

1. Check out changed files in PR

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

Prefix deprecated with WC in includes>export to includes>queue folders.
