### PR TITLE
Prefix deprecated with WC in shipping folder to end

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -88,8 +88,8 @@ class WC_Comments {
 	/**
 	 * Exclude order comments from feed.
 	 *
-	 * @deprecated 3.1
-	 * @param mixed $join Deprecated.
+	 * @deprecated WC-3.1
+	 * @param      mixed $join Deprecated.
 	 */
 	public static function exclude_order_comments_from_feed_join( $join ) {
 		wc_deprecated_function( 'WC_Comments::exclude_order_comments_from_feed_join', '3.1' );
@@ -120,8 +120,8 @@ class WC_Comments {
 	/**
 	 * Exclude webhooks comments from feed.
 	 *
-	 * @deprecated 3.1
-	 * @param mixed $join Deprecated.
+	 * @deprecated WC-3.1
+	 * @param      mixed $join Deprecated.
 	 */
 	public static function exclude_webhook_comments_from_feed_join( $join ) {
 		wc_deprecated_function( 'WC_Comments::exclude_webhook_comments_from_feed_join', '3.1' );

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -824,7 +824,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	/**
 	 * Check if a coupon is valid for the cart.
 	 *
-	 * @deprecated 3.2.0 In favor of WC_Discounts->is_coupon_valid.
+	 * @deprecated WC-3.2.0 In favor of WC_Discounts->is_coupon_valid.
 	 * @return bool
 	 */
 	public function is_valid() {

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -173,7 +173,7 @@ class WC_Download_Handler {
 	 * Count download.
 	 *
 	 * @deprecated unknown
-	 * @param array $download_data Download data.
+	 * @param      array $download_data Download data.
 	 */
 	public static function count_download( $download_data ) {}
 

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -648,8 +648,8 @@ class WC_Emails {
 	/**
 	 * Adds Schema.org markup for order in JSON-LD format.
 	 *
-	 * @deprecated 3.0.0
-	 * @see WC_Structured_Data::generate_order_data()
+	 * @deprecated WC-3.0.0
+	 * @see        WC_Structured_Data::generate_order_data()
 	 *
 	 * @since WC-2.6.0
 	 * @param WC_Order $order         Order instance.

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -644,7 +644,7 @@ class WC_Form_Handler {
 	/**
 	 * Place a previous order again.
 	 *
-	 * @deprecated 3.5.0 Logic moved to cart session handling.
+	 * @deprecated WC-3.5.0 Logic moved to cart session handling.
 	 */
 	public static function order_again() {
 		wc_deprecated_function( 'WC_Form_Handler::order_again', '3.5', 'This method should not be called manually.' );

--- a/includes/class-wc-geo-ip.php
+++ b/includes/class-wc-geo-ip.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Geo_IP Class.
  *
- * @deprecated 3.4.0
+ * @deprecated WC-3.4.0
  */
 class WC_Geo_IP {
 

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -20,14 +20,14 @@ class WC_Geolocation {
 	/**
 	 * GeoLite IPv4 DB.
 	 *
-	 * @deprecated 3.4.0
+	 * @deprecated WC-3.4.0
 	 */
 	const GEOLITE_DB = 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz';
 
 	/**
 	 * GeoLite IPv6 DB.
 	 *
-	 * @deprecated 3.4.0
+	 * @deprecated WC-3.4.0
 	 */
 	const GEOLITE_IPV6_DB = 'http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz';
 

--- a/includes/class-wc-order-item-coupon.php
+++ b/includes/class-wc-order-item-coupon.php
@@ -137,8 +137,8 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @return mixed
+	 * @param      string $offset Offset.
+	 * @return     mixed
 	 */
 	public function offsetGet( $offset ) {
 		if ( 'discount_amount' === $offset ) {
@@ -153,8 +153,8 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @param mixed  $value  Value.
+	 * @param      string $offset Offset.
+	 * @param      mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
 		if ( 'discount_amount' === $offset ) {

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -286,8 +286,8 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @return mixed
+	 * @param      string $offset Offset.
+	 * @return     mixed
 	 */
 	public function offsetGet( $offset ) {
 		if ( 'line_total' === $offset ) {
@@ -304,8 +304,8 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @param mixed  $value  Value.
+	 * @param      string $offset Offset.
+	 * @param      mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
 		if ( 'line_total' === $offset ) {

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -418,8 +418,8 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @return mixed
+	 * @param      string $offset Offset.
+	 * @return     mixed
 	 */
 	public function offsetGet( $offset ) {
 		if ( 'line_subtotal' === $offset ) {
@@ -442,8 +442,8 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @param mixed  $value  Value.
+	 * @param      string $offset Offset.
+	 * @param      mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
 		if ( 'line_subtotal' === $offset ) {

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -272,8 +272,8 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	 * Offset get: for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Key.
-	 * @return mixed
+	 * @param      string $offset Key.
+	 * @return     mixed
 	 */
 	public function offsetGet( $offset ) {
 		if ( 'cost' === $offset ) {
@@ -286,8 +286,8 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	 * Offset set: for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Key.
-	 * @param mixed  $value Value to set.
+	 * @param      string $offset Key.
+	 * @param      mixed  $value Value to set.
 	 */
 	public function offsetSet( $offset, $value ) {
 		if ( 'cost' === $offset ) {

--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -224,8 +224,8 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * O for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @return mixed
+	 * @param      string $offset Offset.
+	 * @return     mixed
 	 */
 	public function offsetGet( $offset ) {
 		if ( 'tax_amount' === $offset ) {
@@ -240,8 +240,8 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
 	 * @deprecated Add deprecation notices in future release.
-	 * @param string $offset Offset.
-	 * @param mixed  $value  Value.
+	 * @param      string $offset Offset.
+	 * @param      mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
 		if ( 'tax_amount' === $offset ) {

--- a/includes/class-wc-order-refund.php
+++ b/includes/class-wc-order-refund.php
@@ -183,9 +183,9 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	/**
 	 * Gets an refund from the database.
 	 *
-	 * @deprecated 3.0
-	 * @param int $id (default: 0).
-	 * @return bool
+	 * @deprecated WC-3.0
+	 * @param      int $id (default: 0).
+	 * @return     bool
 	 */
 	public function get_refund( $id = 0 ) {
 		wc_deprecated_function( 'get_refund', '3.0', 'read' );
@@ -207,8 +207,8 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	/**
 	 * Get refund amount.
 	 *
-	 * @deprecated 3.0
-	 * @return int|float
+	 * @deprecated WC-3.0
+	 * @return     int|float
 	 */
 	public function get_refund_amount() {
 		wc_deprecated_function( 'get_refund_amount', '3.0', 'get_amount' );
@@ -218,8 +218,8 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	/**
 	 * Get refund reason.
 	 *
-	 * @deprecated 3.0
-	 * @return int|float
+	 * @deprecated WC-3.0
+	 * @return     int|float
 	 */
 	public function get_refund_reason() {
 		wc_deprecated_function( 'get_refund_reason', '3.0', 'get_reason' );

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -82,7 +82,7 @@ class WC_Payment_Gateways {
 		);
 
 		/**
-		 * Simplify Commerce is @deprecated in 2.6.0. Only load when enabled.
+		 * Simplify Commerce is @deprecated in WC-2.6.0. Only load when enabled.
 		 */
 		if ( ! class_exists( 'WC_Gateway_Simplify_Commerce_Loader' ) && in_array( WC()->countries->get_base_country(), apply_filters( 'woocommerce_gateway_simplify_commerce_supported_countries', array( 'US', 'IE' ) ), true ) ) {
 			$simplify_options = get_option( 'woocommerce_simplify_commerce_settings', array() );

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -491,10 +491,10 @@ class WC_Post_Data {
 	/**
 	 * Update changed downloads.
 	 *
-	 * @deprecated 3.3.0 No action is necessary on changes to download paths since download_id is no longer based on file hash.
-	 * @param int   $product_id   Product ID.
-	 * @param int   $variation_id Variation ID. Optional product variation identifier.
-	 * @param array $downloads    Newly set files.
+	 * @deprecated WC-3.3.0 No action is necessary on changes to download paths since download_id is no longer based on file hash.
+	 * @param      int   $product_id   Product ID.
+	 * @param      int   $variation_id Variation ID. Optional product variation identifier.
+	 * @param      array $downloads    Newly set files.
 	 */
 	public static function process_product_file_download_paths( $product_id, $variation_id, $downloads ) {
 		wc_deprecated_function( __FUNCTION__, '3.3' );

--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -150,8 +150,8 @@ class WC_Product_Download implements ArrayAccess {
 	/**
 	 * Set previous_hash.
 	 *
-	 * @deprecated 3.3.0 No longer using filename based hashing to keep track of files.
-	 * @param string $value Previous hash.
+	 * @deprecated WC-3.3.0 No longer using filename based hashing to keep track of files.
+	 * @param      string $value Previous hash.
 	 */
 	public function set_previous_hash( $value ) {
 		wc_deprecated_function( __FUNCTION__, '3.3' );
@@ -201,8 +201,8 @@ class WC_Product_Download implements ArrayAccess {
 	/**
 	 * Get previous_hash.
 	 *
-	 * @deprecated 3.3.0 No longer using filename based hashing to keep track of files.
-	 * @return string
+	 * @deprecated WC-3.3.0 No longer using filename based hashing to keep track of files.
+	 * @return     string
 	 */
 	public function get_previous_hash() {
 		wc_deprecated_function( __FUNCTION__, '3.3' );

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -794,9 +794,9 @@ class WC_Query {
 	/**
 	 * Order by rating post clauses.
 	 *
-	 * @deprecated 3.0.0
-	 * @param array $args
-	 * @return array
+	 * @deprecated WC-3.0.0
+	 * @param      array $args
+	 * @return     array
 	 */
 	public function order_by_rating_post_clauses( $args ) {
 		global $wpdb;
@@ -818,8 +818,8 @@ class WC_Query {
 	/**
 	 * Return a meta query for filtering by rating.
 	 *
-	 * @deprecated 3.0.0 Replaced with taxonomy.
-	 * @return array
+	 * @deprecated WC-3.0.0 Replaced with taxonomy.
+	 * @return     array
 	 */
 	public function rating_filter_meta_query() {
 		return array();
@@ -828,9 +828,9 @@ class WC_Query {
 	/**
 	 * Returns a meta query to handle product visibility.
 	 *
-	 * @deprecated 3.0.0 Replaced with taxonomy.
-	 * @param string $compare (default: 'IN')
-	 * @return array
+	 * @deprecated WC-3.0.0 Replaced with taxonomy.
+	 * @param      string $compare (default: 'IN')
+	 * @return     array
 	 */
 	public function visibility_meta_query( $compare = 'IN' ) {
 		return array();
@@ -839,9 +839,9 @@ class WC_Query {
 	/**
 	 * Returns a meta query to handle product stock status.
 	 *
-	 * @deprecated 3.0.0 Replaced with taxonomy.
-	 * @param string $status (default: 'instock')
-	 * @return array
+	 * @deprecated WC-3.0.0 Replaced with taxonomy.
+	 * @param      string $status (default: 'instock')
+	 * @return     array
 	 */
 	public function stock_status_meta_query( $status = 'instock' ) {
 		return array();
@@ -850,7 +850,7 @@ class WC_Query {
 	/**
 	 * Layered nav init.
 	 *
-	 * @deprecated 2.6.0
+	 * @deprecated WC-2.6.0
 	 */
 	public function layered_nav_init() {
 		wc_deprecated_function( 'layered_nav_init', '2.6' );
@@ -859,7 +859,7 @@ class WC_Query {
 	/**
 	 * Get an unpaginated list all product IDs (both filtered and unfiltered). Makes use of transients.
 	 *
-	 * @deprecated 2.6.0 due to performance concerns
+	 * @deprecated WC-2.6.0 due to performance concerns
 	 */
 	public function get_products_in_view() {
 		wc_deprecated_function( 'get_products_in_view', '2.6' );
@@ -868,7 +868,7 @@ class WC_Query {
 	/**
 	 * Layered Nav post filter.
 	 *
-	 * @deprecated 2.6.0 due to performance concerns
+	 * @deprecated WC-2.6.0 due to performance concerns
 	 *
 	 * @param mixed $deprecated Deprecated.
 	 */
@@ -879,7 +879,7 @@ class WC_Query {
 	/**
 	 * Search post excerpt.
 	 *
-	 * @deprecated 3.2.0 - Not needed anymore since WordPress 4.5.
+	 * @deprecated WC-3.2.0 - Not needed anymore since WordPress 4.5.
 	 */
 	public function search_post_excerpt( $where = '' ) {
 		wc_deprecated_function( 'WC_Query::search_post_excerpt', '3.2.0', 'Excerpt added to search query by default since WordPress 4.5.' );
@@ -888,7 +888,7 @@ class WC_Query {
 
 	/**
 	 * Remove the posts_where filter.
-	 * @deprecated 3.2.0 - Nothing to remove anymore because search_post_excerpt() is deprecated.
+	 * @deprecated WC-3.2.0 - Nothing to remove anymore because search_post_excerpt() is deprecated.
 	 */
 	public function remove_posts_where() {
 		wc_deprecated_function( 'WC_Query::remove_posts_where', '3.2.0', 'Nothing to remove anymore because search_post_excerpt() is deprecated.' );

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -367,7 +367,7 @@ class WC_Shipping {
 	/**
 	 * Deprecated
 	 *
-	 * @deprecated 2.6.0 Was previously used to determine sort order of methods, but this is now controlled by zones and thus unused.
+	 * @deprecated WC-2.6.0 Was previously used to determine sort order of methods, but this is now controlled by zones and thus unused.
 	 */
 	public function sort_shipping_methods() {
 		wc_deprecated_function( 'sort_shipping_methods', '2.6' );

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -591,7 +591,7 @@ class WC_Shortcodes {
 	/**
 	 * Order by rating.
 	 *
-	 * @deprecated 3.2.0 Use WC_Shortcode_Products::order_by_rating_post_clauses().
+	 * @deprecated WC-3.2.0 Use WC_Shortcode_Products::order_by_rating_post_clauses().
 	 * @param      array $args Query args.
 	 * @return     array
 	 */

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -497,9 +497,9 @@ class WC_Tax {
 	/**
 	 * Alias for get_base_tax_rates().
 	 *
-	 * @deprecated 2.3
-	 * @param   string	Tax Class
-	 * @return  array
+	 * @deprecated WC-2.3
+	 * @param      string	Tax Class
+	 * @return     array
 	 */
 	public static function get_shop_base_rate( $tax_class = '' ) {
 		return self::get_base_tax_rates( $tax_class );

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -496,10 +496,10 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 * + request headers/body
 	 * + response code/message/headers/body
 	 *
-	 * @since WC-2.2
-	 * @deprecated 3.3.0
-	 * @param int $delivery_id Delivery ID.
-	 * @return void
+	 * @since      WC-2.2
+	 * @deprecated WC-3.3.0
+	 * @param      int $delivery_id Delivery ID.
+	 * @return     void
 	 */
 	public function get_delivery_log( $delivery_id ) {
 		wc_deprecated_function( 'WC_Webhook::get_delivery_log', '3.3' );

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -512,7 +512,7 @@ final class WooCommerce {
 	 * Ensure theme and server variable compatibility and setup image sizes.
 	 */
 	public function setup_environment() {
-		/* @deprecated 2.2 Use WC()->template_path() instead. */
+		/* @deprecated WC-2.2 Use WC()->template_path() instead. */
 		$this->define( 'WC_TEMPLATE_PATH', $this->template_path() );
 
 		$this->add_thumbnail_support();

--- a/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -78,7 +78,7 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 		$this->tax_status   = $this->get_option( 'tax_status' );
 		$this->cost         = $this->get_option( 'cost' );
 		$this->type         = $this->get_option( 'type', 'class' );
-		$this->options      = $this->get_option( 'options', false ); // @deprecated in 2.4.0
+		$this->options      = $this->get_option( 'options', false ); // @deprecated in WC-2.4.0
 	}
 
 	/**
@@ -294,7 +294,7 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	/**
 	 * Adds extra calculated flat rates.
 	 *
-	 * @deprecated 2.4.0
+	 * @deprecated WC-2.4.0
 	 *
 	 * Additional rates defined like this:
 	 *  Option Name | Additional Cost [+- Percents%] | Per Cost Type (order, class, or item).
@@ -329,12 +329,12 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	/**
 	 * Calculate the percentage adjustment for each shipping rate.
 	 *
-	 * @deprecated 2.4.0
-	 * @param  float  $cost Cost.
-	 * @param  float  $percent_adjustment Percent adjusment.
-	 * @param  string $percent_operator Percent operator.
-	 * @param  float  $base_price Base price.
-	 * @return float
+	 * @deprecated WC-2.4.0
+	 * @param      float  $cost Cost.
+	 * @param      float  $percent_adjustment Percent adjusment.
+	 * @param      string $percent_operator Percent operator.
+	 * @param      float  $base_price Base price.
+	 * @return     float
 	 */
 	public function calc_percentage_adjustment( $cost, $percent_adjustment, $percent_operator, $base_price ) {
 		if ( '+' === $percent_operator ) {
@@ -348,11 +348,11 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	/**
 	 * Get extra cost.
 	 *
-	 * @deprecated 2.4.0
-	 * @param  string $cost_string Cost string.
-	 * @param  string $type Type.
-	 * @param  array  $package Package information.
-	 * @return float
+	 * @deprecated WC-2.4.0
+	 * @param      string $cost_string Cost string.
+	 * @param      string $type Type.
+	 * @param      array  $package Package information.
+	 * @return     float
 	 */
 	public function get_extra_cost( $cost_string, $type, $package ) {
 		$cost         = $cost_string;

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -110,7 +110,7 @@ class WC_Shortcode_My_Account {
 	private static function my_account( $atts ) {
 		$args = shortcode_atts(
 			array(
-				'order_count' => 15, // @deprecated 2.6.0. Keep for backward compatibility.
+				'order_count' => 15, // @deprecated WC-2.6.0. Keep for backward compatibility.
 			), $atts, 'woocommerce_my_account'
 		);
 
@@ -142,7 +142,7 @@ class WC_Shortcode_My_Account {
 
 		wc_get_template(
 			'myaccount/view-order.php', array(
-				'status'   => $status, // @deprecated 2.2.
+				'status'   => $status, // @deprecated WC-2.2.
 				'order'    => wc_get_order( $order_id ),
 				'order_id' => $order_id,
 			)

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -39,9 +39,9 @@ function wc_empty_cart() {
 /**
  * Load the persistent cart.
  *
- * @param string  $user_login User login.
- * @param WP_User $user       User data.
- * @deprecated 2.3
+ * @param      string  $user_login User login.
+ * @param      WP_User $user       User data.
+ * @deprecated WC-2.3
  */
 function wc_load_persistent_cart( $user_login, $user ) {
 	if ( ! $user || ! apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -136,7 +136,7 @@ function wc_deprecated_argument( $argument, $version, $message = null ) {
 }
 
 /**
- * @deprecated 2.1
+ * @deprecated WC-2.1
  */
 function woocommerce_show_messages() {
 	wc_deprecated_function( 'woocommerce_show_messages', '2.1', 'wc_print_notices' );
@@ -144,35 +144,35 @@ function woocommerce_show_messages() {
 }
 
 /**
- * @deprecated 2.1
+ * @deprecated WC-2.1
  */
 function woocommerce_weekend_area_js() {
 	wc_deprecated_function( 'woocommerce_weekend_area_js', '2.1' );
 }
 
 /**
- * @deprecated 2.1
+ * @deprecated WC-2.1
  */
 function woocommerce_tooltip_js() {
 	wc_deprecated_function( 'woocommerce_tooltip_js', '2.1' );
 }
 
 /**
- * @deprecated 2.1
+ * @deprecated WC-2.1
  */
 function woocommerce_datepicker_js() {
 	wc_deprecated_function( 'woocommerce_datepicker_js', '2.1' );
 }
 
 /**
- * @deprecated 2.1
+ * @deprecated WC-2.1
  */
 function woocommerce_admin_scripts() {
 	wc_deprecated_function( 'woocommerce_admin_scripts', '2.1' );
 }
 
 /**
- * @deprecated 2.1
+ * @deprecated WC-2.1
  */
 function woocommerce_create_page( $slug, $option = '', $page_title = '', $page_content = '', $post_parent = 0 ) {
 	wc_deprecated_function( 'woocommerce_create_page', '2.1', 'wc_create_page' );
@@ -180,7 +180,7 @@ function woocommerce_create_page( $slug, $option = '', $page_title = '', $page_c
 }
 
 /**
- * @deprecated 2.1
+ * @deprecated WC-2.1
  */
 function woocommerce_readfile_chunked( $file, $retbytes = true ) {
 	wc_deprecated_function( 'woocommerce_readfile_chunked', '2.1', 'WC_Download_Handler::readfile_chunked()' );
@@ -190,10 +190,10 @@ function woocommerce_readfile_chunked( $file, $retbytes = true ) {
 /**
  * Formal total costs - format to the number of decimal places for the base currency.
  *
- * @access public
- * @param mixed $number
- * @deprecated 2.1
- * @return string
+ * @access     public
+ * @param      mixed $number
+ * @deprecated WC-2.1
+ * @return     string
  */
 function woocommerce_format_total( $number ) {
 	wc_deprecated_function( __FUNCTION__, '2.1', 'wc_format_decimal()' );
@@ -203,10 +203,10 @@ function woocommerce_format_total( $number ) {
 /**
  * Get product name with extra details such as SKU price and attributes. Used within admin.
  *
- * @access public
- * @param WC_Product $product
- * @deprecated 2.1
- * @return string
+ * @access     public
+ * @param      WC_Product $product
+ * @deprecated WC-2.1
+ * @return     string
  */
 function woocommerce_get_formatted_product_name( $product ) {
 	wc_deprecated_function( __FUNCTION__, '2.1', 'WC_Product::get_formatted_name()' );
@@ -227,7 +227,7 @@ function woocommerce_legacy_paypal_ipn() {
 add_action( 'init', 'woocommerce_legacy_paypal_ipn' );
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function get_product( $the_product = false, $args = array() ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_product' );
@@ -235,7 +235,7 @@ function get_product( $the_product = false, $args = array() ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_protected_product_add_to_cart( $passed, $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_protected_product_add_to_cart' );
@@ -243,7 +243,7 @@ function woocommerce_protected_product_add_to_cart( $passed, $product_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_empty_cart() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_empty_cart' );
@@ -251,7 +251,7 @@ function woocommerce_empty_cart() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_load_persistent_cart( $user_login, $user = 0 ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_load_persistent_cart' );
@@ -259,7 +259,7 @@ function woocommerce_load_persistent_cart( $user_login, $user = 0 ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_add_to_cart_message( $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_add_to_cart_message' );
@@ -267,7 +267,7 @@ function woocommerce_add_to_cart_message( $product_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_clear_cart_after_payment() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_clear_cart_after_payment' );
@@ -275,7 +275,7 @@ function woocommerce_clear_cart_after_payment() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_cart_totals_subtotal_html() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_subtotal_html' );
@@ -283,7 +283,7 @@ function woocommerce_cart_totals_subtotal_html() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_cart_totals_shipping_html() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_shipping_html' );
@@ -291,7 +291,7 @@ function woocommerce_cart_totals_shipping_html() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_cart_totals_coupon_html( $coupon ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_coupon_html' );
@@ -299,7 +299,7 @@ function woocommerce_cart_totals_coupon_html( $coupon ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_cart_totals_order_total_html() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_order_total_html' );
@@ -307,7 +307,7 @@ function woocommerce_cart_totals_order_total_html() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_cart_totals_fee_html( $fee ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_fee_html' );
@@ -315,7 +315,7 @@ function woocommerce_cart_totals_fee_html( $fee ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_cart_totals_shipping_method_label( $method ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cart_totals_shipping_method_label' );
@@ -323,7 +323,7 @@ function woocommerce_cart_totals_shipping_method_label( $method ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_template_part( $slug, $name = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_template_part' );
@@ -331,7 +331,7 @@ function woocommerce_get_template_part( $slug, $name = '' ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_template' );
@@ -339,7 +339,7 @@ function woocommerce_get_template( $template_name, $args = array(), $template_pa
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_locate_template( $template_name, $template_path = '', $default_path = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_locate_template' );
@@ -347,7 +347,7 @@ function woocommerce_locate_template( $template_name, $template_path = '', $defa
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_mail( $to, $subject, $message, $headers = "Content-Type: text/html\r\n", $attachments = "" ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_mail' );
@@ -355,7 +355,7 @@ function woocommerce_mail( $to, $subject, $message, $headers = "Content-Type: te
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_disable_admin_bar( $show_admin_bar ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_disable_admin_bar' );
@@ -363,7 +363,7 @@ function woocommerce_disable_admin_bar( $show_admin_bar ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_create_new_customer( $email, $username = '', $password = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_create_new_customer' );
@@ -371,7 +371,7 @@ function woocommerce_create_new_customer( $email, $username = '', $password = ''
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_set_customer_auth_cookie( $customer_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_set_customer_auth_cookie' );
@@ -379,7 +379,7 @@ function woocommerce_set_customer_auth_cookie( $customer_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_update_new_customer_past_orders( $customer_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_update_new_customer_past_orders' );
@@ -387,7 +387,7 @@ function woocommerce_update_new_customer_past_orders( $customer_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_paying_customer( $order_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_paying_customer' );
@@ -395,7 +395,7 @@ function woocommerce_paying_customer( $order_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_customer_bought_product( $customer_email, $user_id, $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_customer_bought_product' );
@@ -403,7 +403,7 @@ function woocommerce_customer_bought_product( $customer_email, $user_id, $produc
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_customer_has_capability' );
@@ -411,7 +411,7 @@ function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_sanitize_taxonomy_name( $taxonomy ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_sanitize_taxonomy_name' );
@@ -419,7 +419,7 @@ function woocommerce_sanitize_taxonomy_name( $taxonomy ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_filename_from_url( $file_url ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_filename_from_url' );
@@ -427,7 +427,7 @@ function woocommerce_get_filename_from_url( $file_url ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_dimension( $dim, $to_unit ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_dimension' );
@@ -435,7 +435,7 @@ function woocommerce_get_dimension( $dim, $to_unit ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_weight( $weight, $to_unit ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_weight' );
@@ -443,7 +443,7 @@ function woocommerce_get_weight( $weight, $to_unit ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_trim_zeros( $price ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_trim_zeros' );
@@ -451,7 +451,7 @@ function woocommerce_trim_zeros( $price ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_round_tax_total( $tax ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_round_tax_total' );
@@ -459,7 +459,7 @@ function woocommerce_round_tax_total( $tax ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_format_decimal' );
@@ -467,7 +467,7 @@ function woocommerce_format_decimal( $number, $dp = false, $trim_zeros = false )
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_clean( $var ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_clean' );
@@ -475,7 +475,7 @@ function woocommerce_clean( $var ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_array_overlay( $a1, $a2 ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_array_overlay' );
@@ -483,7 +483,7 @@ function woocommerce_array_overlay( $a1, $a2 ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_price( $price, $args = array() ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_price' );
@@ -491,7 +491,7 @@ function woocommerce_price( $price, $args = array() ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_let_to_num( $size ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_let_to_num' );
@@ -499,7 +499,7 @@ function woocommerce_let_to_num( $size ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_date_format() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_date_format' );
@@ -507,7 +507,7 @@ function woocommerce_date_format() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_time_format() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_time_format' );
@@ -515,7 +515,7 @@ function woocommerce_time_format() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_timezone_string() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_timezone_string' );
@@ -524,7 +524,7 @@ function woocommerce_timezone_string() {
 
 if ( ! function_exists( 'woocommerce_rgb_from_hex' ) ) {
 	/**
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 */
 	function woocommerce_rgb_from_hex( $color ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_rgb_from_hex' );
@@ -534,7 +534,7 @@ if ( ! function_exists( 'woocommerce_rgb_from_hex' ) ) {
 
 if ( ! function_exists( 'woocommerce_hex_darker' ) ) {
 	/**
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 */
 	function woocommerce_hex_darker( $color, $factor = 30 ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_hex_darker' );
@@ -544,7 +544,7 @@ if ( ! function_exists( 'woocommerce_hex_darker' ) ) {
 
 if ( ! function_exists( 'woocommerce_hex_lighter' ) ) {
 	/**
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 */
 	function woocommerce_hex_lighter( $color, $factor = 30 ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_hex_lighter' );
@@ -554,7 +554,7 @@ if ( ! function_exists( 'woocommerce_hex_lighter' ) ) {
 
 if ( ! function_exists( 'woocommerce_light_or_dark' ) ) {
 	/**
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 */
 	function woocommerce_light_or_dark( $color, $dark = '#000000', $light = '#FFFFFF' ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_light_or_dark' );
@@ -564,7 +564,7 @@ if ( ! function_exists( 'woocommerce_light_or_dark' ) ) {
 
 if ( ! function_exists( 'woocommerce_format_hex' ) ) {
 	/**
-	 * @deprecated 3.0
+	 * @deprecated WC-3.0
 	 */
 	function woocommerce_format_hex( $hex ) {
 		wc_deprecated_function( __FUNCTION__, '3.0', 'wc_format_hex' );
@@ -573,7 +573,7 @@ if ( ! function_exists( 'woocommerce_format_hex' ) ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_order_id_by_order_key( $order_key ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_order_id_by_order_key' );
@@ -581,7 +581,7 @@ function woocommerce_get_order_id_by_order_key( $order_key ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_downloadable_file_permission( $download_id, $product_id, $order ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_downloadable_file_permission' );
@@ -589,7 +589,7 @@ function woocommerce_downloadable_file_permission( $download_id, $product_id, $o
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_downloadable_product_permissions( $order_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_downloadable_product_permissions' );
@@ -597,7 +597,7 @@ function woocommerce_downloadable_product_permissions( $order_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_add_order_item( $order_id, $item ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_add_order_item' );
@@ -605,7 +605,7 @@ function woocommerce_add_order_item( $order_id, $item ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_delete_order_item( $item_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_delete_order_item' );
@@ -613,7 +613,7 @@ function woocommerce_delete_order_item( $item_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_update_order_item_meta( $item_id, $meta_key, $meta_value, $prev_value = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_update_order_item_meta' );
@@ -621,7 +621,7 @@ function woocommerce_update_order_item_meta( $item_id, $meta_key, $meta_value, $
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_add_order_item_meta( $item_id, $meta_key, $meta_value, $unique = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_add_order_item_meta' );
@@ -629,7 +629,7 @@ function woocommerce_add_order_item_meta( $item_id, $meta_key, $meta_value, $uni
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_delete_order_item_meta( $item_id, $meta_key, $meta_value = '', $delete_all = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_delete_order_item_meta' );
@@ -637,7 +637,7 @@ function woocommerce_delete_order_item_meta( $item_id, $meta_key, $meta_value = 
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_order_item_meta( $item_id, $key, $single = true ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_order_item_meta' );
@@ -645,7 +645,7 @@ function woocommerce_get_order_item_meta( $item_id, $key, $single = true ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_cancel_unpaid_orders() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_cancel_unpaid_orders' );
@@ -653,7 +653,7 @@ function woocommerce_cancel_unpaid_orders() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_processing_order_count() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_processing_order_count' );
@@ -661,7 +661,7 @@ function woocommerce_processing_order_count() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_page_id( $page ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_page_id' );
@@ -669,7 +669,7 @@ function woocommerce_get_page_id( $page ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_endpoint_url' );
@@ -677,7 +677,7 @@ function woocommerce_get_endpoint_url( $endpoint, $value = '', $permalink = '' )
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_lostpassword_url( $url ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_lostpassword_url' );
@@ -685,7 +685,7 @@ function woocommerce_lostpassword_url( $url ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_customer_edit_account_url() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_customer_edit_account_url' );
@@ -693,7 +693,7 @@ function woocommerce_customer_edit_account_url() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_nav_menu_items( $items, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_nav_menu_items' );
@@ -701,7 +701,7 @@ function woocommerce_nav_menu_items( $items, $args ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_nav_menu_item_classes( $menu_items, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_nav_menu_item_classes' );
@@ -709,7 +709,7 @@ function woocommerce_nav_menu_item_classes( $menu_items, $args ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_list_pages( $pages ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_list_pages' );
@@ -717,7 +717,7 @@ function woocommerce_list_pages( $pages ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_product_dropdown_categories( $args = array(), $deprecated_hierarchical = 1, $deprecated_show_uncategorized = 1, $deprecated_orderby = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_product_dropdown_categories' );
@@ -725,7 +725,7 @@ function woocommerce_product_dropdown_categories( $args = array(), $deprecated_h
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_walk_category_dropdown_tree( $a1 = '', $a2 = '', $a3 = '' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_walk_category_dropdown_tree' );
@@ -733,21 +733,21 @@ function woocommerce_walk_category_dropdown_tree( $a1 = '', $a2 = '', $a3 = '' )
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_taxonomy_metadata_wpdbfix() {
 	wc_deprecated_function( __FUNCTION__, '3.0' );
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function wc_taxonomy_metadata_wpdbfix() {
 	wc_deprecated_function( __FUNCTION__, '3.0' );
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_order_terms( $the_term, $next_id, $taxonomy, $index = 0, $terms = null ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_reorder_terms' );
@@ -755,7 +755,7 @@ function woocommerce_order_terms( $the_term, $next_id, $taxonomy, $index = 0, $t
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_set_term_order' );
@@ -763,7 +763,7 @@ function woocommerce_set_term_order( $term_id, $index, $taxonomy, $recursive = f
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_terms_clauses( $clauses, $taxonomies, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_terms_clauses' );
@@ -771,7 +771,7 @@ function woocommerce_terms_clauses( $clauses, $taxonomies, $args ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function _woocommerce_term_recount( $terms, $taxonomy, $callback, $terms_are_term_taxonomy_ids ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', '_wc_term_recount' );
@@ -779,7 +779,7 @@ function _woocommerce_term_recount( $terms, $taxonomy, $callback, $terms_are_ter
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_recount_after_stock_change( $product_id ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_recount_after_stock_change' );
@@ -787,7 +787,7 @@ function woocommerce_recount_after_stock_change( $product_id ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_change_term_counts( $terms, $taxonomies, $args ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_change_term_counts' );
@@ -795,7 +795,7 @@ function woocommerce_change_term_counts( $terms, $taxonomies, $args ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_product_ids_on_sale() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_product_ids_on_sale' );
@@ -803,7 +803,7 @@ function woocommerce_get_product_ids_on_sale() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_featured_product_ids() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_featured_product_ids' );
@@ -811,7 +811,7 @@ function woocommerce_get_featured_product_ids() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_product_terms( $object_id, $taxonomy, $fields = 'all' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_product_terms' );
@@ -819,7 +819,7 @@ function woocommerce_get_product_terms( $object_id, $taxonomy, $fields = 'all' )
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_product_post_type_link( $permalink, $post ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_product_post_type_link' );
@@ -827,7 +827,7 @@ function woocommerce_product_post_type_link( $permalink, $post ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_placeholder_img_src() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_placeholder_img_src' );
@@ -835,7 +835,7 @@ function woocommerce_placeholder_img_src() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_placeholder_img( $size = 'woocommerce_thumbnail' ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_placeholder_img' );
@@ -843,7 +843,7 @@ function woocommerce_placeholder_img( $size = 'woocommerce_thumbnail' ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_formatted_variation' );
@@ -851,7 +851,7 @@ function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_scheduled_sales() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_scheduled_sales' );
@@ -859,7 +859,7 @@ function woocommerce_scheduled_sales() {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_get_attachment_image_attributes( $attr ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_get_attachment_image_attributes' );
@@ -867,7 +867,7 @@ function woocommerce_get_attachment_image_attributes( $attr ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_prepare_attachment_for_js( $response ) {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_prepare_attachment_for_js' );
@@ -875,7 +875,7 @@ function woocommerce_prepare_attachment_for_js( $response ) {
 }
 
 /**
- * @deprecated 3.0
+ * @deprecated WC-3.0
  */
 function woocommerce_track_product_view() {
 	wc_deprecated_function( __FUNCTION__, '3.0', 'wc_track_product_view' );
@@ -883,7 +883,7 @@ function woocommerce_track_product_view() {
 }
 
 /**
- * @since  WC-2.3
+ * @since      WC-2.3
  * @deprecated has no replacement
  */
 function woocommerce_compile_less_styles() {
@@ -905,8 +905,8 @@ function woocommerce_calc_shipping_backwards_compatibility( $value ) {
 add_filter( 'pre_option_woocommerce_calc_shipping', 'woocommerce_calc_shipping_backwards_compatibility' );
 
 /**
- * @deprecated 3.0.0
- * @see WC_Structured_Data class
+ * @deprecated WC-3.0.0
+ * @see        WC_Structured_Data class
  *
  * @return string
  */
@@ -940,12 +940,12 @@ function woocommerce_get_product_schema() {
  *
  * This is a private function (internal use ONLY) used until a data manipulation api is built.
  *
- * @deprecated 3.0.0
- * @param int $product_id
- * @param float $regular_price
- * @param float $sale_price
- * @param string $date_from
- * @param string $date_to
+ * @deprecated WC-3.0.0
+ * @param      int $product_id
+ * @param      float $regular_price
+ * @param      float $sale_price
+ * @param      string $date_from
+ * @param      string $date_to
  */
 function _wc_save_product_price( $product_id, $regular_price, $sale_price = '', $date_from = '', $date_to = '' ) {
 	wc_doing_it_wrong( '_wc_save_product_price()', 'This function is not for developer use and is deprecated.', '3.0' );
@@ -989,10 +989,10 @@ function _wc_save_product_price( $product_id, $regular_price, $sale_price = '', 
 /**
  * Return customer avatar URL.
  *
- * @deprecated 3.1.0
- * @since WC-2.6.0
- * @param string $email the customer's email.
- * @return string the URL to the customer's avatar.
+ * @deprecated WC-3.1.0
+ * @since      WC-2.6.0
+ * @param      string $email the customer's email.
+ * @return     string the URL to the customer's avatar.
  */
 function wc_get_customer_avatar_url( $email ) {
 	// Deprecated in favor of WordPress get_avatar_url() function.
@@ -1004,9 +1004,9 @@ function wc_get_customer_avatar_url( $email ) {
 /**
  * ClassicCommerce Core Supported Themes.
  *
- * @deprecated 3.3.0
- * @since WC-2.2
- * @return string[]
+ * @deprecated WC-3.3.0
+ * @since      WC-2.2
+ * @return     string[]
  */
 function wc_get_core_supported_themes() {
 	wc_deprecated_function( 'wc_get_core_supported_themes()', '3.3' );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2229,9 +2229,10 @@ if ( ! function_exists( 'woocommerce_product_subcategories' ) ) {
 	 * This is a legacy function which also checks if things should display.
 	 * Themes no longer need to call these functions. It's all done via hooks.
 	 *
-	 * @deprecated 3.3.1 @todo Add a notice in a future version.
-	 * @param array $args Arguments.
-	 * @return null|boolean
+	 * @deprecated WC-3.3.1
+	 * @todo       Add a notice in a future version.
+	 * @param      array $args Arguments.
+	 * @return     null|boolean
 	 */
 	function woocommerce_product_subcategories( $args = array() ) {
 		$defaults = array(
@@ -3369,7 +3370,7 @@ function woocommerce_output_all_notices() {
 /**
  * Products RSS Feed.
  *
- * @deprecated 2.6
+ * @deprecated WC-2.6
  */
 function wc_products_rss_feed() {
 	wc_deprecated_function( 'wc_products_rss_feed', '2.6' );
@@ -3380,7 +3381,7 @@ if ( ! function_exists( 'woocommerce_reset_loop' ) ) {
 	/**
 	 * Reset the loop's index and columns when we're done outputting a product loop.
 	 *
-	 * @deprecated 3.3
+	 * @deprecated WC-3.3
 	 */
 	function woocommerce_reset_loop() {
 		wc_reset_loop();
@@ -3391,7 +3392,7 @@ if ( ! function_exists( 'woocommerce_product_reviews_tab' ) ) {
 	/**
 	 * Output the reviews tab content.
 	 *
-	 * @deprecated 2.4.0 Unused.
+	 * @deprecated WC-2.4.0 Unused.
 	 */
 	function woocommerce_product_reviews_tab() {
 		wc_deprecated_function( 'woocommerce_product_reviews_tab', '2.4' );

--- a/includes/widgets/class-wc-widget-product-tag-cloud.php
+++ b/includes/widgets/class-wc-widget-product-tag-cloud.php
@@ -95,9 +95,9 @@ class WC_Widget_Product_Tag_Cloud extends WC_Widget {
 	/**
 	 * Return the taxonomy being displayed.
 	 *
-	 * @deprecated 3.4.0
-	 * @param  object $instance Widget instance.
-	 * @return string
+	 * @deprecated WC-3.4.0
+	 * @param      object $instance Widget instance.
+	 * @return     string
 	 */
 	public function _get_current_taxonomy( $instance ) {
 		wc_deprecated_function( '_get_current_taxonomy', '3.4.0', 'WC_Widget_Product_Tag_Cloud->get_current_taxonomy' );
@@ -107,10 +107,10 @@ class WC_Widget_Product_Tag_Cloud extends WC_Widget {
 	/**
 	 * Returns topic count text.
 	 *
-	 * @deprecated 3.4.0
-	 * @since WC-2.6.0
-	 * @param int $count Count text.
-	 * @return string
+	 * @deprecated WC-3.4.0
+	 * @since      WC-2.6.0
+	 * @param      int $count Count text.
+	 * @return     string
 	 */
 	public function _topic_count_text( $count ) {
 		wc_deprecated_function( '_topic_count_text', '3.4.0', 'WC_Widget_Product_Tag_Cloud->topic_count_text' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prefix deprecated with WC in includes>shipping folder to end of includes folder.

### How to test the changes in this Pull Request:

1. Check out changes to files in PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

Prefix deprecated with WC in includes>shipping folder to end of includes folder.
