### PR TITLE
Change WC to CC in setup wizard

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1089,7 +1089,7 @@ class WC_Admin_Setup_Wizard {
 				printf(
 					wp_kses(
 						/* translators: %s: Link */
-						__( 'WooCommerce can accept both online and offline payments. A <a href="%1$s" target="_blank">basic PayPal option</a> is already included. This can be enabled and configured from the Payments tab under Settings. <a href="%2$s" target="_blank">Additional payment methods</a> can be installed later.', 'classic-commerce' ),
+						__( 'Classic Commerce can accept both online and offline payments. A <a href="%1$s" target="_blank">basic PayPal option</a> is already included. This can be enabled and configured from the Payments tab under Settings. <a href="%2$s" target="_blank">Additional payment methods</a> can be installed later.', 'classic-commerce' ),
 						array(
 							'a' => array(
 								'href'   => array(),
@@ -1223,7 +1223,7 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function wc_setup_recommended() {
 		?>
-		<h1><?php esc_html_e( 'Recommended for All WooCommerce Stores', 'classic-commerce' ); ?></h1>
+		<h1><?php esc_html_e( 'Recommended for all Classic Commerce stores', 'classic-commerce' ); ?></h1>
 
 		<form method="post">
 			<p class="wc-setup-actions step">
@@ -1245,7 +1245,7 @@ class WC_Admin_Setup_Wizard {
 		$docs_url     = 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/';
 		$help_text    = sprintf(
 			/* translators: %1$s: link to videos, %2$s: link to docs */
-			__( 'Watch <a href="%1$s" target="_blank">guided tour videos</a> to learn more about WooCommerce, and visit WooCommerce.com to learn more about <a href="%2$s" target="_blank">getting started</a>.', 'classic-commerce' ),
+			__( 'Watch <a href="%1$s" target="_blank">guided tour videos</a> to learn more about Classic Commerce, or visit WooCommerce.com to learn more about <a href="%2$s" target="_blank">getting started</a>.', 'classic-commerce' ),
 			$videos_url,
 			$docs_url
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change a few occurrences of WooCommerce to Classic Commerce that were previously missed in the setup wizard.

### How to test the changes in this Pull Request:

1. Copy changes file class-wc-admin-setup-wizard.php to a test site
2. Run the setup wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Change WC to CC in setup wizard.
