### PR TITLE
Change WC to CC in importers

### DIFF
--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -110,8 +110,8 @@ class WC_Admin_Importers {
 	public function register_importers() {
 		if ( defined( 'WP_LOAD_IMPORTERS' ) ) {
 			add_action( 'import_start', array( $this, 'post_importer_compatibility' ) );
-			register_importer( 'woocommerce_product_csv', __( 'WooCommerce products (CSV)', 'classic-commerce' ), __( 'Import <strong>products</strong> to your store via a csv file.', 'classic-commerce' ), array( $this, 'product_importer' ) );
-			register_importer( 'woocommerce_tax_rate_csv', __( 'WooCommerce tax rates (CSV)', 'classic-commerce' ), __( 'Import <strong>tax rates</strong> to your store via a csv file.', 'classic-commerce' ), array( $this, 'tax_rates_importer' ) );
+			register_importer( 'woocommerce_product_csv', __( 'Classic Commerce products (CSV)', 'classic-commerce' ), __( 'Import <strong>products</strong> to your store via a csv file.', 'classic-commerce' ), array( $this, 'product_importer' ) );
+			register_importer( 'woocommerce_tax_rate_csv', __( 'Classic Commerce tax rates (CSV)', 'classic-commerce' ), __( 'Import <strong>tax rates</strong> to your store via a csv file.', 'classic-commerce' ), array( $this, 'tax_rates_importer' ) );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change WC to CC in importers. This shows up in Tools -> Import section of CMS.

![import](https://user-images.githubusercontent.com/46998578/68535807-58ee1180-039c-11ea-91ab-3680a83fad3e.jpg)

Closes # .

### How to test the changes in this Pull Request:

1. Copy changed file admin\class-wc-admin-importers.php to a test site
2. Go to Tools -> Import section and see new titles available.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Change WC to CC in importers

