### PR TITLE
Fix brand name without breaking the styles and scripts loading

### DIFF
--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -18,7 +18,10 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 	class WC_Admin_Assets {
 
 		/**
-		 * Add screen_id variable.
+		 * Add screen_id variable for WC_Admin_Assets class.
+		 *
+		 * @since CC-1.0.0
+		 * @var String
 		 */
 		protected $wc_screen_id;
 

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -81,7 +81,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 			$screen       = get_current_screen();
 			$screen_id    = $screen ? $screen->id : '';
-			$wc_screen_id = sanitize_title( __( 'WooCommerce', 'classic-commerce' ) );
+			$wc_screen_id = sanitize_title( __( 'Classic Commerce', 'classic-commerce' ) );
 			$suffix       = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 			// Register scripts.

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -18,11 +18,17 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 	class WC_Admin_Assets {
 
 		/**
+		 * Add screen_id variable.
+		 */
+		protected $wc_screen_id;
+
+		/**
 		 * Hook in tabs.
 		 */
 		public function __construct() {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+			$this->wc_screen_id = sanitize_title( __( 'Classic Commerce', 'classic-commerce' ) );
 		}
 
 		/**
@@ -61,7 +67,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_style( 'woocommerce_admin_dashboard_styles' );
 			}
 
-			if ( in_array( $screen_id, array( 'woocommerce_page_wc-reports', 'toplevel_page_wc-reports' ) ) ) {
+			if ( in_array( $screen_id, array( $this->wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports' ) ) ) {
 				wp_enqueue_style( 'woocommerce_admin_print_reports_styles' );
 			}
 
@@ -81,7 +87,6 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 			$screen       = get_current_screen();
 			$screen_id    = $screen ? $screen->id : '';
-			$wc_screen_id = sanitize_title( __( 'Classic Commerce', 'classic-commerce' ) );
 			$suffix       = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 			// Register scripts.
@@ -365,7 +370,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Reports Pages.
-			if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports', 'dashboard' ) ) ) ) {
+			if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $this->wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports', 'dashboard' ) ) ) ) {
 				wp_register_script( 'wc-reports', WC()->plugin_url() . '/assets/js/admin/reports' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker' ), WC_VERSION );
 
 				wp_enqueue_script( 'wc-reports' );
@@ -377,7 +382,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// API settings.
-			if ( $wc_screen_id . '_page_wc-settings' === $screen_id && isset( $_GET['section'] ) && 'keys' == $_GET['section'] ) {
+			if ( $this->wc_screen_id . '_page_wc-settings' === $screen_id && isset( $_GET['section'] ) && 'keys' == $_GET['section'] ) {
 				wp_register_script( 'wc-api-keys', WC()->plugin_url() . '/assets/js/admin/api-keys' . $suffix . '.js', array( 'jquery', 'woocommerce_admin', 'underscore', 'backbone', 'wp-util', 'qrcode', 'wc-clipboard' ), WC_VERSION, true );
 				wp_enqueue_script( 'wc-api-keys' );
 				wp_localize_script(
@@ -392,7 +397,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// System status.
-			if ( $wc_screen_id . '_page_wc-status' === $screen_id ) {
+			if ( $this->wc_screen_id . '_page_wc-status' === $screen_id ) {
 				wp_register_script( 'wc-admin-system-status', WC()->plugin_url() . '/assets/js/admin/system-status' . $suffix . '.js', array( 'wc-clipboard' ), WC_VERSION );
 				wp_enqueue_script( 'wc-admin-system-status' );
 				wp_localize_script(

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -56,11 +56,7 @@ class WC_Admin_Menus {
 			$menu[] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' ); // WPCS: override ok.
 		}
 
-<<<<<<< develop
-		add_menu_page( __( 'Classic Commerce', 'classic-commerce' ), __( 'WooCommerce', 'classic-commerce' ), 'manage_woocommerce', 'woocommerce', null, null, '55.5' );
-=======
-		add_menu_page( __( 'Classic Commerce', 'classic-commerce' ), __( 'Classic Commerce', 'classic-commerce' ), 'manage_woocommerce', 'woocommerce', null, WC()->plugin_url() . '/assets/images/classiccommerce-icon-white.svg', '55.5' );
->>>>>>> local
+		add_menu_page( __( 'Classic Commerce', 'classic-commerce' ), __( 'Classic Commerce', 'classic-commerce' ), 'manage_woocommerce', 'woocommerce', null, null, '55.5' );
 
 		add_submenu_page( 'edit.php?post_type=product', __( 'Attributes', 'classic-commerce' ), __( 'Attributes', 'classic-commerce' ), 'manage_product_terms', 'product_attributes', array( $this, 'attributes_page' ) );
 	}

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -56,7 +56,11 @@ class WC_Admin_Menus {
 			$menu[] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' ); // WPCS: override ok.
 		}
 
+<<<<<<< develop
 		add_menu_page( __( 'Classic Commerce', 'classic-commerce' ), __( 'WooCommerce', 'classic-commerce' ), 'manage_woocommerce', 'woocommerce', null, null, '55.5' );
+=======
+		add_menu_page( __( 'Classic Commerce', 'classic-commerce' ), __( 'Classic Commerce', 'classic-commerce' ), 'manage_woocommerce', 'woocommerce', null, WC()->plugin_url() . '/assets/images/classiccommerce-icon-white.svg', '55.5' );
+>>>>>>> local
 
 		add_submenu_page( 'edit.php?post_type=product', __( 'Attributes', 'classic-commerce' ), __( 'Attributes', 'classic-commerce' ), 'manage_product_terms', 'product_attributes', array( $this, 'attributes_page' ) );
 	}

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function wc_get_screen_ids() {
 
-	$wc_screen_id = sanitize_title( __( 'WooCommerce', 'classic-commerce' ) );
+	$wc_screen_id = sanitize_title( __( 'Classic Commerce', 'classic-commerce' ) );
 	$screen_ids   = array(
 		'toplevel_page_' . $wc_screen_id,
 		$wc_screen_id . '_page_wc-reports',


### PR DESCRIPTION
### All Submissions:
Change the plugin name without breaking the styles and scripts.

I have found the same string `$this->wc_screen_id = sanitize_title( __( 'Classic Commerce', 'classic-commerce' ) );` that is translated attached to several files:
`includes/admin/class-wc-admin-assets.php`
`includes/admin/class-wc-admin-menus.php`
`includes/admin/wc-admin-functions.php`

The questions are
1. Should this be translated in any case? 
1. Should this become a site wide constant via define()?

It simply adds a portion of a screen_id name and also adds to the plugin default name.

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

![Screenshot 2019-11-11 at 15 09 24](https://user-images.githubusercontent.com/7713923/68588434-87eaad00-049a-11ea-931e-7158cf72e94d.png) 

Closes Partially 102.

### Changelog entry

> Change `WooCommerce` name to `Classic Commerce`.