### PR TITLE
Override the admin page name with CSS

### DIFF
--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -23,6 +23,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		public function __construct() {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+			add_action( 'admin_head', array( $this, 'admin_menu_inline_css' ) );
 		}
 
 		/**
@@ -416,6 +417,42 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					)
 				);
 			}
+		}
+
+		/**
+		 * Enqueue inline CSS for the admin menu.
+		 *
+		 * We register the top-level menu item as __( 'WooCommerce' ), which
+		 * causes the admin screen ID to be
+		 * `sanitize_title( __( 'WooCommerce' ) )`.
+		 *
+		 * This is still 'WooCommerce' for compatibility with extensions that
+		 * need to use screen IDs directly.  More info:
+		 *
+		 * - https://www.skyverge.com/blog/screen-id-checks-wordpress-submenu-pages/
+		 * - https://wpdirectory.net/search/01DSDNR9N8X79VRR1F01GZ3HVP
+		 * - https://github.com/ClassicPress-research/classic-commerce/pull/TODO
+		 *
+		 * To avoid showing WooCommerce in the admin menu, we override that
+		 * text with CSS, echoed inline so that the name can be translated.
+		 *
+		 * @since 1.0.0
+		 */
+		public function admin_menu_inline_css() {
+?>
+<style>
+ul#adminmenu > li#toplevel_page_woocommerce > a > div.wp-menu-name {
+	font-size: 0px;
+	color: rgba(0, 0, 0, 0);
+}
+ul#adminmenu > li#toplevel_page_woocommerce > a > div.wp-menu-name:after {
+	font-size: 14px;
+	color: #eee;
+	display: inline;
+	content: "<?php _e( 'Commerce', 'classic-commerce' ); ?>";
+}
+</style>
+<?php
 		}
 	}
 

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -431,7 +431,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 *
 		 * - https://www.skyverge.com/blog/screen-id-checks-wordpress-submenu-pages/
 		 * - https://wpdirectory.net/search/01DSDNR9N8X79VRR1F01GZ3HVP
-		 * - https://github.com/ClassicPress-research/classic-commerce/pull/TODO
+		 * - https://github.com/ClassicPress-research/classic-commerce/pull/118
 		 *
 		 * To avoid showing WooCommerce in the admin menu, we override that
 		 * text with CSS, echoed inline so that the name can be translated.


### PR DESCRIPTION
### Summary

This PR provides an alternative to #115, which will break some extensions that rely on the admin screen IDs for WooCommerce pages.  Due to quirks of the WordPress admin menu system, the screen ID is based on the **translated** version of the menu title.  More info:  https://www.skyverge.com/blog/screen-id-checks-wordpress-submenu-pages/

Some of these plugins may break if the menu item title (and therefore the screen ID) is changed from `__( 'WooCommerce' )`: https://wpdirectory.net/search/01DSDNR9N8X79VRR1F01GZ3HVP

This PR leaves the menu item **registered** as WooCommerce, but then overrides the **displayed title** via CSS.  The CSS is echoed inline to allow the title to be translated.

I've also used "Commerce" instead of "Classic Commerce" for the menu title, because "Classic Commerce" is a bit too long for this space.  When the logo is changed to the CC logo this should still be pretty clear.

The rest of the standard pull request template follows...

### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Visit the admin dashboard with the plugin installed.
2. Verify that the admin menu now says "Commerce" instead of "WooCommerce" as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Change admin menu title without breaking extensions that rely on WooCommerce-based screen IDs