### PR TITLE
Override the admin page name using a filter

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -31,6 +31,7 @@ class WC_Admin_Menus {
 			add_action( 'admin_menu', array( $this, 'addons_menu' ), 70 );
 		}
 
+		add_action( 'admin_menu', array( $this, 'admin_menu_rename' ), PHP_INT_MAX - 1 );
 		add_action( 'admin_head', array( $this, 'menu_highlight' ) );
 		add_action( 'admin_head', array( $this, 'menu_order_count' ) );
 		add_filter( 'menu_order', array( $this, 'menu_order' ) );
@@ -127,9 +128,32 @@ class WC_Admin_Menus {
 	 * Addons menu item.
 	 */
 	public function addons_menu() {
-		
 		$menu_title = __( 'Extensions', 'classic-commerce' );
 		add_submenu_page( 'woocommerce', __( 'Classic Commerce extensions', 'classic-commerce' ), $menu_title, 'manage_woocommerce', 'wc-addons', array( $this, 'addons_page' ) );
+	}
+
+	/**
+	 * Rename the top-level menu item.
+	 *
+	 * This is still registered as WooCommerce for compatibility with existing
+	 * extensions that use the screen ID.  More info:
+	 *
+	 * - https://www.skyverge.com/blog/screen-id-checks-wordpress-submenu-pages/
+	 * - https://wpdirectory.net/search/01DSDNR9N8X79VRR1F01GZ3HVP
+	 * - https://github.com/ClassicPress-research/classic-commerce/pull/119
+	 *
+	 * Based on https://gist.github.com/geoffspink/e191a7cad8c9a23f5c60.
+	 *
+	 * @since 1.0.0
+	 */
+	public function admin_menu_rename() {
+		global $menu;
+		foreach ( $menu as $key => &$value ) {
+			if ( $value[5] === 'toplevel_page_woocommerce' ) {
+				$value[0] = esc_html__( 'Commerce', 'classic-commerce' );
+				break;
+			}
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -139,7 +139,7 @@ class WC_Admin_Menus {
 	 * extensions that use the screen ID.  More info:
 	 *
 	 * - https://www.skyverge.com/blog/screen-id-checks-wordpress-submenu-pages/
-	 * - https://wpdirectory.net/search/01DSDNR9N8X79VRR1F01GZ3HVP
+	 * - https://wpdirectory.net, search for "sanitize_title.{0,90}woocommerce"
 	 * - https://github.com/ClassicPress-research/classic-commerce/pull/119
 	 *
 	 * Based on https://gist.github.com/geoffspink/e191a7cad8c9a23f5c60.


### PR DESCRIPTION
### Summary

This PR provides an alternative to #115, which will break some extensions that rely on the admin screen IDs for WooCommerce pages.  Due to quirks of the WordPress admin menu system, the screen ID is based on the **translated** version of the menu title.  More info:  https://www.skyverge.com/blog/screen-id-checks-wordpress-submenu-pages/

Some of these plugins may break if the menu item title (and therefore the screen ID) is changed from `__( 'WooCommerce' )`: https://wpdirectory.net/search/01DSDNR9N8X79VRR1F01GZ3HVP

This PR leaves the menu item **registered** as WooCommerce, but then overrides the **displayed title** via a filter.

I've also used "Commerce" instead of "Classic Commerce" for the menu title, because "Classic Commerce" is a bit too long for this space.  When the logo is changed to the CC logo this should still be pretty clear.

The rest of the standard pull request template follows...

### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Visit the admin dashboard with the plugin installed.
2. Verify that the admin menu now says "Commerce" instead of "WooCommerce" as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Change admin menu title without breaking extensions that rely on WooCommerce-based screen IDs

As currently written, this is a **breaking change** for stores that are using an approach like https://gist.github.com/geoffspink/e191a7cad8c9a23f5c60 to customize the admin menu title! They will need to use `PHP_INT_MAX` as their new filter priority instead.