### PR TITLE
Fix PHP notices in admin menu

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -149,7 +149,7 @@ class WC_Admin_Menus {
 	public function admin_menu_rename() {
 		global $menu;
 		foreach ( $menu as $key => &$value ) {
-			if ( $value[5] === 'toplevel_page_woocommerce' ) {
+			if ( isset( $value[5] ) && $value[5] === 'toplevel_page_woocommerce' ) {
 				$value[0] = esc_html__( 'Commerce', 'classic-commerce' );
 				break;
 			}


### PR DESCRIPTION
Follow-up to #119.

Fixes the following PHP notices that occur in the new code introduced there:

![2019-11-11T20-02-30Z](https://user-images.githubusercontent.com/227022/68617095-5a175f80-04be-11ea-927b-55c67b76baff.png)

Not all menu items have a `$value[5]` property (looks like it's the "separator" items that don't have it).