### PR TITLE
Change WC to CC in user agent parameters

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -193,7 +193,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			'redirection' => 0,
 			'httpversion' => '1.0',
 			'blocking'    => true,
-			'user-agent'  => sprintf( 'WooCommerce/%s Hookshot (WordPress/%s)', WC_VERSION, $GLOBALS['wp_version'] ),
+			'user-agent'  => sprintf( 'ClassicCommerce/%s Hookshot (WordPress/%s)', WC_VERSION, $GLOBALS['wp_version'] ),
 			'body'        => trim( wp_json_encode( $payload ) ),
 			'headers'     => array(
 				'Content-Type' => 'application/json',
@@ -513,7 +513,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 */
 	public function deliver_ping() {
 		$args = array(
-			'user-agent' => sprintf( 'WooCommerce/%s Hookshot (WordPress/%s)', WC_VERSION, $GLOBALS['wp_version'] ),
+			'user-agent' => sprintf( 'ClassicCommerce/%s Hookshot (WordPress/%s)', WC_VERSION, $GLOBALS['wp_version'] ),
 			'body'       => 'webhook_id=' . $this->get_id(),
 		);
 

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-api-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-api-handler.php
@@ -108,7 +108,7 @@ class WC_Gateway_Paypal_API_Handler {
 				'method'      => 'POST',
 				'body'        => self::get_capture_request( $order, $amount ),
 				'timeout'     => 70,
-				'user-agent'  => 'WooCommerce/' . WC()->version,
+				'user-agent'  => 'ClassicCommerce/' . WC()->version,
 				'httpversion' => '1.1',
 			)
 		);
@@ -141,7 +141,7 @@ class WC_Gateway_Paypal_API_Handler {
 				'method'      => 'POST',
 				'body'        => self::get_refund_request( $order, $amount, $reason ),
 				'timeout'     => 70,
-				'user-agent'  => 'WooCommerce/' . WC()->version,
+				'user-agent'  => 'ClassicCommerce/' . WC()->version,
 				'httpversion' => '1.1',
 			)
 		);

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -92,7 +92,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 			'httpversion' => '1.1',
 			'compress'    => false,
 			'decompress'  => false,
-			'user-agent'  => 'WooCommerce/' . WC()->version,
+			'user-agent'  => 'ClassicCommerce/' . WC()->version,
 		);
 
 		// Post back to get a response.

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
@@ -51,7 +51,7 @@ class WC_Gateway_Paypal_PDT_Handler extends WC_Gateway_Paypal_Response {
 			),
 			'timeout'     => 60,
 			'httpversion' => '1.1',
-			'user-agent'  => 'WooCommerce/' . WC_VERSION,
+			'user-agent'  => 'ClassicCommerce/' . WC_VERSION,
 		);
 
 		// Post back to get a response.

--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -78,7 +78,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway_CC {
 
 		Simplify::$publicKey  = $this->public_key;
 		Simplify::$privateKey = $this->private_key;
-		Simplify::$userAgent  = 'WooCommerce/' . WC()->version;
+		Simplify::$userAgent  = 'ClassicCommerce/' . WC()->version;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change WC to CC in various user agent parameters.

PLEASE CHECK CAREFULLY. 
class-wc-webhook.php has this line that also calls WP version (?).
`'user-agent'  => sprintf( 'ClassicCommerce/%s Hookshot (WordPress/%s)', WC_VERSION, $GLOBALS['wp_version'] ),`

### How to test the changes in this Pull Request:

1. Check out changed files in PR


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Change WC to CC in various user agent parameters
