### PR TITLE
Change WC to CC order records

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1629,8 +1629,8 @@ class WC_Order extends WC_Abstract_Order {
 			$comment_author       = $user->display_name;
 			$comment_author_email = $user->user_email;
 		} else {
-			$comment_author        = __( 'WooCommerce', 'classic-commerce' );
-			$comment_author_email  = strtolower( __( 'WooCommerce', 'classic-commerce' ) ) . '@';
+			$comment_author        = __( 'ClassicCommerce', 'classic-commerce' );
+			$comment_author_email  = strtolower( __( 'ClassicCommerce', 'classic-commerce' ) ) . '@';
 			$comment_author_email .= isset( $_SERVER['HTTP_HOST'] ) ? str_replace( 'www.', '', sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) ) : 'noreply.com'; // WPCS: input var ok.
 			$comment_author_email  = sanitize_email( $comment_author_email );
 		}
@@ -1642,7 +1642,7 @@ class WC_Order extends WC_Abstract_Order {
 				'comment_author_email' => $comment_author_email,
 				'comment_author_url'   => '',
 				'comment_content'      => $note,
-				'comment_agent'        => 'WooCommerce',
+				'comment_agent'        => 'ClassicCommerce',
 				'comment_type'         => 'order_note',
 				'comment_parent'       => 0,
 				'comment_approved'     => 1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change WC to CC in order records as defined in class-wc-order.php.

### How to test the changes in this Pull Request:

1. Check out the changed file in the PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Change WC to CC in order records.
