### PR TITLE
Change links to CP forum to relocated support area

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can follow up on the development cycle by reading our [roadmap](https://gith
 To disclose a security issue to our team. (security@classicpress.net)
 
 ## Support
-This repository is most suitable for development but can also be used for support. We will add a support tag to your issue. However, this might take a little longer to get a response. You can also use the dedicated support area on the [ClassicPress community forum](https://forums.classicpress.net/c/plugins/plugin-support/).
+This repository is most suitable for development but can also be used for support. We will add a support tag to your issue. However, this might take a little longer to get a response. You can also use the dedicated support area on the [ClassicPress community forum](https://forums.classicpress.net/tags/classic-commerce/).
 
 ## Contributing to Classic Commerce
 If you have a patch or have stumbled upon an issue with Classic Commerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md) for more information about how you can do this.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can follow up on the development cycle by reading our [roadmap](https://gith
 To disclose a security issue to our team. (security@classicpress.net)
 
 ## Support
-This repository is most suitable for development but can also be used for support. We will add a support tag to your issue. However, this might take a little longer to get a response. You can also use the dedicated support area on the [ClassicPress community forum](https://forums.classicpress.net/c/support/classic-commerce/).
+This repository is most suitable for development but can also be used for support. We will add a support tag to your issue. However, this might take a little longer to get a response. You can also use the dedicated support area on the [ClassicPress community forum](https://forums.classicpress.net/c/plugins/plugin-support/).
 
 ## Contributing to Classic Commerce
 If you have a patch or have stumbled upon an issue with Classic Commerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md) for more information about how you can do this.

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -50,10 +50,10 @@ class WC_Admin_Help {
 					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
 						__( 'For further assistance with Classic Commerce you can use the <a href="%1$s">ClassicPress community forum</a>.', 'classic-commerce' ),
-						'https://forums.classicpress.net/c/plugins/plugin-support'
+						'https://forums.classicpress.net/tags/classic-commerce/'
 					) . '</p>' .
 					'<p>' . __( 'Before asking for help we recommend using the system status page to identify any problems with your configuration. You should make a copy of this report to add to your support request.', 'classic-commerce' ) . '</p>' .
-					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'classic-commerce' ) . '</a> <a href="https://forums.classicpress.net/c/plugins/plugin-support" class="button">' . __( 'Community forum', 'classic-commerce' ) . '</a></p>',
+					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'classic-commerce' ) . '</a> <a href="https://forums.classicpress.net/tags/classic-commerce/" class="button">' . __( 'Community forum', 'classic-commerce' ) . '</a></p>',
 			)
 		);
 

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -50,10 +50,10 @@ class WC_Admin_Help {
 					'<p>' . sprintf(
 						/* translators: %s: Forum URL */
 						__( 'For further assistance with Classic Commerce you can use the <a href="%1$s">ClassicPress community forum</a>.', 'classic-commerce' ),
-						'https://forums.classicpress.net/c/support/classic-commerce'
+						'https://forums.classicpress.net/c/plugins/plugin-support'
 					) . '</p>' .
 					'<p>' . __( 'Before asking for help we recommend using the system status page to identify any problems with your configuration. You should make a copy of this report to add to your support request.', 'classic-commerce' ) . '</p>' .
-					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'classic-commerce' ) . '</a> <a href=" https://forums.classicpress.net/c/support/classic-commerce" class="button">' . __( 'Community forum', 'classic-commerce' ) . '</a></p>',
+					'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System status', 'classic-commerce' ) . '</a> <a href="https://forums.classicpress.net/c/plugins/plugin-support" class="button">' . __( 'Community forum', 'classic-commerce' ) . '</a></p>',
 			)
 		);
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p><?php esc_html_e( 'Before installing and using any extensions or plugins we strongly recommend that you first work in a test environment. If you are working on a live site please ensure that you have a recent backup.', 'classic-commerce' ); ?></p>
 
-	<p><?php printf( __( 'For discussion and help with finding compatible Classic Commerce addons, use the <a href="%s">ClassicPress community forum</a>.', 'classic-commerce' ), 'https://forums.classicpress.net/c/plugins/plugin-support/' ); ?></p>
+	<p><?php printf( __( 'For discussion and help with finding compatible Classic Commerce addons, use the <a href="%s">ClassicPress community forum</a>.', 'classic-commerce' ), 'https://forums.classicpress.net/tags/classic-commerce/' ); ?></p>
 
 	<p><?php printf( __( 'For problems with the Classic Commerce core files please raise an issue via <a href="%s">Github issues</a>.', 'classic-commerce' ), 'https://github.com/ClassicPress-research/classic-commerce/issues/' ); ?></p>
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p><?php esc_html_e( 'Before installing and using any extensions or plugins we strongly recommend that you first work in a test environment. If you are working on a live site please ensure that you have a recent backup.', 'classic-commerce' ); ?></p>
 
-	<p><?php printf( __( 'For discussion and help with finding compatible Classic Commerce addons, use the <a href="%s">ClassicPress community forum</a>.', 'classic-commerce' ), 'https://forums.classicpress.net/c/support/classic-commerce/' ); ?></p>
+	<p><?php printf( __( 'For discussion and help with finding compatible Classic Commerce addons, use the <a href="%s">ClassicPress community forum</a>.', 'classic-commerce' ), 'https://forums.classicpress.net/c/plugins/plugin-support/' ); ?></p>
 
 	<p><?php printf( __( 'For problems with the Classic Commerce core files please raise an issue via <a href="%s">Github issues</a>.', 'classic-commerce' ), 'https://github.com/ClassicPress-research/classic-commerce/issues/' ); ?></p>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Support area on the ClassicPress forum has been moved following discussions. The links in the help area ( x 2) and on the extensions page (x 1) have been changed to point to the new support area.

### How to test the changes in this Pull Request:

1. Copy changed links to a test site.
2. Check that links now take you to the new support area

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Change links to CP forum to relocated support area.
