### PR TITLE
Add the woocommerce/woocommerce.php to active_plugins options

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -166,6 +166,7 @@ final class WooCommerce {
 	private function init_hooks() {
 		register_activation_hook( WC_PLUGIN_FILE, array( 'WC_Install', 'install' ) );
 		register_shutdown_function( array( $this, 'log_errors' ) );
+		add_filter( 'option_active_plugins', array( $this, 'cc_add_wc_plugin_name_option' ), 10, 1 );
 		add_action( 'after_setup_theme', array( $this, 'setup_environment' ) );
 		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
 		add_action( 'init', array( $this, 'init' ), 0 );
@@ -174,6 +175,16 @@ final class WooCommerce {
 		add_action( 'init', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
+	}
+
+	/**
+	 * Adds a woocommerce/woocommerce.php string to active_plugins options for dependent extensions.
+	 *
+	 * @since CC-1.0.0
+	 */
+	public function cc_add_wc_plugin_name_option($plugins) {
+			$plugins[] = 'woocommerce/woocommerce.php';
+			return $plugins;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:
Some plugins require the `woocommerce/woocommerce.php` file to activate or run some other functions with woocommerce. To keep backward compatibility, it is only right to add a provision for this. This PR seeks to close #131 

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Install classic-commerce in plugins directory
2. Click activate.
3.

### Other information:
With this change however, unless a fix is done, the plugin has a notice for a missing plugin file. However, the Database retains the added string in the active_plugins options row.
See screenshot below.

![Screenshot 2019-11-23 at 15 06 03](https://user-images.githubusercontent.com/7713923/69483887-ec641f80-0e3d-11ea-9657-9739f460f3d1.png)

### Changelog entry

> Backward compatibility fix. Some plugins require the `woocommerce/woocommerce.php` file to activate or run some other functions with woocommerce.
