### PR TITLE
Updates WC version number and status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -70,8 +70,8 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 			<td><?php echo esc_html( $environment['cc_version'] ); ?></td>
 		</tr>
 		<tr>
-			<td data-export-label="WC Version"><?php esc_html_e( 'WooCommerce version', 'classic-commerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of WooCommerce installed on your site.', 'classic-commerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td data-export-label="WC Version"><?php esc_html_e( 'WooCommerce equivalent version', 'classic-commerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Equivalent version of WooCommerce installed on your site.', 'classic-commerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $environment['version'] ); ?></td>
 		</tr>
 		<tr>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -67,6 +67,11 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		<tr>
 			<td data-export-label="CC Version"><?php esc_html_e( 'Classic Commerce version', 'classic-commerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of Classic Commerce installed on your site.', 'classic-commerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td><?php echo esc_html( $environment['cc_version'] ); ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="WC Version"><?php esc_html_e( 'WooCommerce version', 'classic-commerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of WooCommerce installed on your site.', 'classic-commerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $environment['version'] ); ?></td>
 		</tr>
 		<tr>

--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -611,6 +611,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			'home_url'                  => get_option( 'home' ),
 			'site_url'                  => get_option( 'siteurl' ),
 			'version'                   => WC()->version,
+			'cc_version'                => WC()->cc_version,
 			'log_directory'             => WC_LOG_DIR,
 			'log_directory_writable'    => (bool) @fopen( WC_LOG_DIR . 'test-log.log', 'a' ),
 			'wp_version'                => get_bloginfo( 'version' ),

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -119,6 +119,9 @@ class WC_Install {
 		),
 		'3.5.2' => array(
 			'wc_update_352_drop_download_log_fk',
+		),
+		'3.5.3' => array(
+			'wc_update_353_db_version',
 		)
 	);
 
@@ -134,11 +137,20 @@ class WC_Install {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
+		add_action( 'init', array( __CLASS__, 'init_background_updater' ), 5 );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( __CLASS__, 'plugin_row_meta' ), 10, 2 );
 		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );
 		add_filter( 'cron_schedules', array( __CLASS__, 'cron_schedules' ) );
+	}
+	
+	/**
+	 * Init background updates
+	 */
+	public static function init_background_updater() {
+		include_once dirname( __FILE__ ) . '/class-wc-background-updater.php';
+		self::$background_updater = new WC_Background_Updater();
 	}
 
 	/**

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -20,7 +20,8 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '0.1.0';
+	public $version = '3.5.3';
+	public $cc_version = '0.1.0';
 
 	/**
 	 * The single instance of the class.

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1894,3 +1894,10 @@ function wc_update_352_drop_download_log_fk() {
 		$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY fk_wc_download_log_permission_id" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 	}
 }
+
+/**
+ * Update DB Version.
+ */
+function wc_update_353_db_version() {
+	WC_Install::update_db_version( '3.5.3' );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Refer to issues #143 and #145 

Closes #143 and #145  .

### How to test the changes in this Pull Request:

1. Check CC status report. Should show version for CC and WC.
2. Install a plugin that needs WC >= 2.0 but <= 3.5.3

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
1. Changes the version of WC reported by CC to 3.5.3 to help with plugin compatibility.
2. Updates the status report to display the versions of CC and WC.
