### PR TITLE
Add compat plugin optional install admin notice

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -34,6 +34,7 @@ class WC_Admin_Notices {
 		'simplify_commerce'       => 'simplify_commerce_notice',
 		'regenerating_thumbnails' => 'regenerating_thumbnails_notice',
 		'no_secure_connection'    => 'secure_connection_notice',
+		'require_compat_plugin'   => 'require_compat_plugin_notice'
 	);
 
 	/**
@@ -91,6 +92,7 @@ class WC_Admin_Notices {
 		}
 
 		self::add_notice( 'template_files' );
+		self::add_notice( 'require_compat_plugin' );
 	}
 
 	/**
@@ -356,6 +358,13 @@ class WC_Admin_Notices {
 		}
 
 		include dirname( __FILE__ ) . '/views/html-notice-secure-connection.php';
+	}
+
+	/**
+	 * Notice for requiring the Classic Commerce compatibility plugin to run Woocommerce specific extensions.
+	 */
+	public static function require_compat_plugin_notice() {
+		include dirname( __FILE__ ) . '/views/html-notice-require-compat-plugin.php';
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -34,7 +34,7 @@ class WC_Admin_Notices {
 		'simplify_commerce'       => 'simplify_commerce_notice',
 		'regenerating_thumbnails' => 'regenerating_thumbnails_notice',
 		'no_secure_connection'    => 'secure_connection_notice',
-		'require_compat_plugin'   => 'require_compat_plugin_notice'
+		'require_compat_plugin'   => 'require_compat_plugin_notice',
 	);
 
 	/**

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -30,9 +30,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p><?php esc_html_e( 'This is an optional plugin that is seperately installed and activated. Its primary purpose is to ensure Classic Commerce compatibility with extensions that are dependent on the installation of WooCommerce.', 'classic-commerce' ); ?></p>
 	
-	<p><?php printf( __( '<strong>Note:</strong> It does not fix all compatibility issues with extensions apart from specific checks run to detect WooCommerce installation not present in Classic Commerce.', 'classic-commerce' ) ); ?></p>
+	<p><?php printf( __( '<strong>First, uninstall WooCommerce</strong> inorder to run the Compatibility plugin. The two cannot co-exist!', 'classic-commerce' ) ); ?></p>
 
-	<p><?php printf( __( '<strong>Sample checks fixed:</strong>', 'classic-commerce' ) ); ?></p>
+	<p><?php printf( __( '<strong>Note:</strong> The Compatibility plugin does not fix all compatibility issues apart from specific checks the extensions run to detect WooCommerce installation.', 'classic-commerce' ) ); ?></p>
+
+	<p><?php printf( __( '<strong>Sample checks include:</strong>', 'classic-commerce' ) ); ?></p>
 
 	<p><code>in_array( 'woocommerce/woocommerce.php', self::$active_plugins ) || array_key_exists( 'woocommerce/woocommerce.php', self::$active_plugins );</code></p>
 
@@ -44,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<h3><?php esc_html_e( 'Disclaimer', 'classic-commerce' ); ?></h3>
 
-	<p><strong><?php esc_html_e( 'The end user is entirely responsible for choosing, installing, testing and monitoring any extensions or plugins that are needed to provide extra functionality to the Classic Commerce core.', 'classic-commerce' ); ?></strong></p>
+	<p><?php printf( __( '<strong>The end user is entirely responsible</strong> for choosing, installing, testing and monitoring any extensions or plugins that are needed to provide extra functionality to the Classic Commerce core.', 'classic-commerce' ) ); ?></p>
 
 	<p><?php esc_html_e( 'Before installing and using any extensions or plugins we strongly recommend that you first work in a test environment. If you are working on a live site please ensure that you have a recent backup.', 'classic-commerce' ); ?></p>
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -16,13 +16,39 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<hr>
 
-	<p><?php printf( __( '<strong>Important Note: </strong>Although Classic Commerce is a fork of WooCommerce version 3.5.3, all JetPack and WooCommerce Services integration have been removed.', 'classic-commerce' ) ); ?></p>
+	<h3 id="cc-compat"><?php esc_html_e( 'Important Note:', 'classic-commerce' ); ?></h3>
+
+	<p><?php esc_html_e( 'Although Classic Commerce is a fork of WooCommerce version 3.5.3, all JetPack and WooCommerce Services integration have been removed.', 'classic-commerce' ); ?></p>
 
 	<p><?php esc_html_e( 'Many extensions or plugins designed for WooCommerce will still work with Classic Commerce provided they do not rely on Jetpack or WooCommerce Services.', 'classic-commerce' ); ?></p>
+
+	<hr />
+	
+	<h3 id="cc-compat"><?php esc_html_e( 'Classic Commerce Compatibility Plugin', 'classic-commerce' ); ?></h3>
+
+	<p><?php esc_html_e( 'This is an optional plugin that is seperately installed and activated. Its primary purpose is to ensure Classic Commerce compatibility with extensions that are dependent on the installation of WooCommerce.', 'classic-commerce' ); ?></p>
+	
+	<p><?php printf( __( '<strong>Note:</strong> It does not fix all compatibility issues with extensions apart from specific checks run to detect WooCommerce installation not present in Classic Commerce.', 'classic-commerce' ) ); ?></p>
+
+	<p><?php printf( __( '<strong>Sample checks fixed:</strong>', 'classic-commerce' ) ); ?></p>
+
+	<p><code>in_array( 'woocommerce/woocommerce.php', self::$active_plugins ) || array_key_exists( 'woocommerce/woocommerce.php', self::$active_plugins );</code></p>
+
+	<p><code>in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) );</code></p>
+
+	<p><code>is_plugin_active( 'woocommerce/woocommerce.php' )</code></p>
+	
+	<hr />
+
+	<h3><?php esc_html_e( 'Disclaimer', 'classic-commerce' ); ?></h3>
 
 	<p><strong><?php esc_html_e( 'The end user is entirely responsible for choosing, installing, testing and monitoring any extensions or plugins that are needed to provide extra functionality to the Classic Commerce core.', 'classic-commerce' ); ?></strong></p>
 
 	<p><?php esc_html_e( 'Before installing and using any extensions or plugins we strongly recommend that you first work in a test environment. If you are working on a live site please ensure that you have a recent backup.', 'classic-commerce' ); ?></p>
+
+	<hr />
+
+	<h3><?php esc_html_e( 'Feedback:', 'classic-commerce' ); ?></h3>
 
 	<p><?php printf( __( 'For discussion and help with finding compatible Classic Commerce addons, use the <a href="%s">ClassicPress community forum</a>.', 'classic-commerce' ), 'https://forums.classicpress.net/tags/classic-commerce/' ); ?></p>
 
@@ -30,7 +56,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<hr />
 
-	<p><strong><?php esc_html_e( 'GNU General Public License', 'classic-commerce' ); ?></strong></p>
+	<h3><?php esc_html_e( 'GNU General Public License', 'classic-commerce' ); ?></h3>
 
 	<p><?php esc_html_e( 'This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License, version 2, as published by the Free Software Foundation.', 'classic-commerce' ); ?></p>
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p><?php esc_html_e( 'This is an optional plugin that is seperately installed and activated. Its primary purpose is to ensure Classic Commerce compatibility with extensions that are dependent on the installation of WooCommerce.', 'classic-commerce' ); ?></p>
 	
-	<p><?php printf( __( '<strong>First, uninstall WooCommerce</strong> inorder to run the Compatibility plugin. The two cannot co-exist!', 'classic-commerce' ) ); ?></p>
+	<p><?php printf( __( '<strong>First, uninstall WooCommerce</strong> in order to run the Compatibility plugin. The two cannot co-exist!', 'classic-commerce' ) ); ?></p>
 
 	<p><?php printf( __( '<strong>Note:</strong> The Compatibility plugin does not fix all compatibility issues apart from specific checks the extensions run to detect WooCommerce installation.', 'classic-commerce' ) ); ?></p>
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -4,7 +4,9 @@
  *
  * @var string $view
  * @var object $addons
+ * @package Classic Commerce
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Admin View: Notice - Install
+ * Admin View: Notice to Install Compatibility Plugin
+ *
+ * @package Classic Commerce
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 
-	<p><?php _e( 'Are you installing WooCommerce specific extensions? You might require the', 'classic-commerce' ); ?> <a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons#cc-compat' ) ); ?>"><?php _e( 'compatibility plugin.', 'classic-commerce' ); ?></a></p>
+	<p><?php esc_html_e( 'Are you installing WooCommerce specific extensions? You might require the', 'classic-commerce' ); ?> <a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons#cc-compat' ) ); ?>"><?php esc_html_e( 'compatibility plugin.', 'classic-commerce' ); ?></a></p>
 
-	<p class="submit"><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( 'https://github.com/Classic-Commerce/cc-compat-woo/releases' ); ?>" class="button-primary"><?php _e( 'Download compatibility plugin.', 'classic-commerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'require_compat_plugin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php _e( 'Dismiss', 'classic-commerce' ); ?></a></p>
+	<p class="submit"><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( 'https://github.com/Classic-Commerce/cc-compat-woo/releases' ); ?>" class="button-primary"><?php esc_html_e( 'Download compatibility plugin.', 'classic-commerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'require_compat_plugin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'classic-commerce' ); ?></a></p>
 	
 </div>

--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -12,7 +12,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 
-	<p><?php esc_html_e( 'Are you installing WooCommerce specific extensions? You might require the', 'classic-commerce' ); ?> <a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons#cc-compat' ) ); ?>"><?php esc_html_e( 'compatibility plugin.', 'classic-commerce' ); ?></a></p>
+	<p>
+		<?php
+		/*Translators: Notice for Compatibility plugin need.*/
+		echo sprintf( wp_kses( __( 'Are you installing WooCommerce specific extensions? You might require the <a href="%s">compatibility plugin</a>.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'admin.php?page=wc-addons#cc-compat' ) ) );
+		?>
+	</p>
+
+	<p>
+		<?php
+		/*Translators: Warning to uninstall WooCommerce.*/
+		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">uninstall WooCommerce</a> first before installing the Compatibility Plugin.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
+		?>
+	</p>
 
 	<p class="submit"><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( 'https://github.com/Classic-Commerce/cc-compat-woo/releases' ); ?>" class="button-primary"><?php esc_html_e( 'Download compatibility plugin.', 'classic-commerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'require_compat_plugin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'classic-commerce' ); ?></a></p>
 	

--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Admin View: Notice - Install
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+?>
+<div id="message" class="updated woocommerce-message wc-connect">
+
+	<p><?php _e( 'Are you installing WooCommerce specific extensions? You might require the', 'classic-commerce' ); ?> <a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons#cc-compat' ) ); ?>"><?php _e( 'compatibility plugin.', 'classic-commerce' ); ?></a></p>
+
+	<p class="submit"><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( 'https://github.com/Classic-Commerce/cc-compat-woo/releases' ); ?>" class="button-primary"><?php _e( 'Download compatibility plugin.', 'classic-commerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'require_compat_plugin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php _e( 'Dismiss', 'classic-commerce' ); ?></a></p>
+	
+</div>


### PR DESCRIPTION
### All Submissions:

PR is to fulfill requirements of #144. Check other information below.

### Changes proposed in this Pull Request:
- Add admin notice warning user of compatibility plugin and issues it solves.
- Add button to download the compat plugin.
- Add section to extensions page describing the compat plugin.
- Admin notice is persistent unless dismissed. It also returns on deactivation & re-activation of plugin.

![Screenshot 2019-12-22 at 13 31 57](https://user-images.githubusercontent.com/7713923/71321058-34ba4000-24c5-11ea-9199-214b07e57c17.png)

I hit a wall trying to detect if another plugin is using the particular lines of code. However, we can compensate for this by warning the user the issues that might arise. Leave the user to make the decision.

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #144  .

### How to test the changes in this Pull Request:

1. Install classic-commerce into plugins and activate plugin.