### PR TITLE
Fix deactivating wc/cc problem

### DIFF
--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -11,12 +11,15 @@
  *
  * @package WooCommerce
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+
 if ( ! function_exists( 'is_plugin_active' ) ) {
 	include_once ABSPATH . 'wp-admin/includes/plugin.php';
 }
+
 /**
  * Returns error when WooCommerce is detected among the files on the server.
  *
@@ -27,24 +30,33 @@ function cc_wc_already_active_notice() {
 	echo esc_html__( 'You must deactivate WooCommerce before activating Classic Commerce.', 'classic-commerce' );
 	echo '</p></div>';
 }
+
 if ( file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) && file_exists( WP_PLUGIN_DIR . '/woocommerce/includes/class-woocommerce.php' ) && is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+
 	// Woocommerce Files already exist. Show an admin notice.
 	add_action( 'admin_notices', 'cc_wc_already_active_notice' );
+
 	// Deactivate Classic Commerce.
 	deactivate_plugins( array( 'classic-commerce/classic-commerce.php' ) );
+
 	// Do not proceed further with Classic Commerce loading.
 	return;
+
 } else {
+
 	// Load the Update Client to manage Classic Commerce updates.
 	include_once dirname( __FILE__ ) . '/includes/class-wc-update-client.php';
+
 	// Define WC_PLUGIN_FILE.
 	if ( ! defined( 'WC_PLUGIN_FILE' ) ) {
 		define( 'WC_PLUGIN_FILE', __FILE__ );
 	}
+
 	// Include the main WooCommerce class.
 	if ( ! class_exists( 'WooCommerce' ) ) {
 		include_once dirname( __FILE__ ) . '/includes/class-woocommerce.php';
 	}
+
 	/**
 	 * Main instance of WooCommerce.
 	 *
@@ -56,6 +68,8 @@ if ( file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) && file_exist
 	function wc() {
 		return WooCommerce::instance();
 	}
+
 	// Global for backwards compatibility.
 	$GLOBALS['woocommerce'] = wc();
+
 }

--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -11,15 +11,12 @@
  *
  * @package WooCommerce
  */
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
 if ( ! function_exists( 'is_plugin_active' ) ) {
 	include_once ABSPATH . 'wp-admin/includes/plugin.php';
 }
-
 /**
  * Returns error when WooCommerce is detected among the files on the server.
  *
@@ -30,33 +27,24 @@ function cc_wc_already_active_notice() {
 	echo esc_html__( 'You must deactivate WooCommerce before activating Classic Commerce.', 'classic-commerce' );
 	echo '</p></div>';
 }
-
-if ( file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) && file_exists( WP_PLUGIN_DIR . '/woocommerce/includes/class-woocommerce.php' ) && file_exists( WP_PLUGIN_DIR . '/woocommerce/includes/admin/class-wc-admin.php' ) ) {
-
+if ( file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) && file_exists( WP_PLUGIN_DIR . '/woocommerce/includes/class-woocommerce.php' ) && is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 	// Woocommerce Files already exist. Show an admin notice.
 	add_action( 'admin_notices', 'cc_wc_already_active_notice' );
-
 	// Deactivate Classic Commerce.
 	deactivate_plugins( array( 'classic-commerce/classic-commerce.php' ) );
-
 	// Do not proceed further with Classic Commerce loading.
 	return;
-
 } else {
-
 	// Load the Update Client to manage Classic Commerce updates.
 	include_once dirname( __FILE__ ) . '/includes/class-wc-update-client.php';
-
 	// Define WC_PLUGIN_FILE.
 	if ( ! defined( 'WC_PLUGIN_FILE' ) ) {
 		define( 'WC_PLUGIN_FILE', __FILE__ );
 	}
-
 	// Include the main WooCommerce class.
 	if ( ! class_exists( 'WooCommerce' ) ) {
 		include_once dirname( __FILE__ ) . '/includes/class-woocommerce.php';
 	}
-
 	/**
 	 * Main instance of WooCommerce.
 	 *
@@ -68,8 +56,6 @@ if ( file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) && file_exist
 	function wc() {
 		return WooCommerce::instance();
 	}
-
 	// Global for backwards compatibility.
 	$GLOBALS['woocommerce'] = wc();
-
 }

--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p>
 		<?php
 		/*Translators: Warning to delete WooCommerce.*/
-		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin. Deleting WooCommerce will not remove your products, settings and other data.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
+		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
 		?>
 	</p>
 

--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p>
 		<?php
 		/*Translators: Warning to delete WooCommerce.*/
-		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin. Deleting WooCommerce will <strong>not</strong> remove your products, settings and other data.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
+		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin. Deleting WooCommerce will not remove your products, settings and other data.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
 		?>
 	</p>
 

--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p>
 		<?php
 		/*Translators: Warning to delete WooCommerce.*/
-		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
+		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin. Deleting WooCommerce will <strong>not</strong> remove your products, settings and other data.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
 		?>
 	</p>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix code in main classic-commerce.php file to allow deactivating of WC before activating of CC. Change message in html-notice-require-compat-plugin.php to add sentence about deleting WooCommerce not deleting your data.

Closes #165 .

### How to test the changes in this Pull Request:

1. Copy the 2 changed files into a test site with both WC and CC installed
2. Deactivate one and activate the other.
3. Repeat. Observe message when activating CC.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


### Changelog entry

> Allow deactivating of WC before activating of CC. Add message about deleting WooCommerce not deleting your data.
