### PR TITLE
Fix for theme template directory issue #167

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -582,7 +582,8 @@ final class WooCommerce {
 	 * @return string
 	 */
 	public function template_path() {
-		return apply_filters( 'woocommerce_template_path', 'woocommerce/' );
+		$templatepath = file_exists( get_stylesheet_directory() . '/classic-commerce/' ) ? 'classic-commerce/' : 'woocommerce/';
+		return apply_filters( 'woocommerce_template_path', $templatepath );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #167  .

### How to test the changes in this Pull Request:

1. Create a directory called 'woocommerce' below the active theme directory (e.g. 'mytheme/woocommerce').
2. Copy the 'single-product.php' template file from 'plugins/woocommerce/templates' to 'mytheme/woocommerce'.
3. Make a minor modification to this file (e.g. `<?php echo "Hello World"; ?>`). On the frontend product page, you should see **Hello World**.
4. Create a directory called 'classic-commerce' below the active theme directory.
5. Copy the 'single-product.php' template file from 'plugins/woocommerce/templates' to 'mytheme/classic-commerce'.
6. Make a _**different**_ modification to this file (e.g. `<?php echo "Hello Classic Commerce"; ?>`). On the frontend, you should now see **Hello Classic Commerce**.
7. If you delete 'mytheme/woocommerce', you should still see **Hello Classic Commerce**.


### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Added support for template overrides using a directory called 'classic-commerce' below the active theme. The 'classic-commerce' directory takes priority over any existing 'woocommerce' directory.
