### PR TITLE
Change compat plugin warning message

### DIFF
--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p>
 		<?php
 		/*Translators: Warning to delete WooCommerce.*/
-		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
+		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin. Deleting WooCommerce will not remove your products, settings and other data.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
 		?>
 	</p>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a sentence to the compat plugin message to say that deleting WC will not lose any data.

![new-message](https://user-images.githubusercontent.com/46998578/72210469-2a152880-3510-11ea-9fc0-aaa439adca27.jpg)

### How to test the changes in this Pull Request:

1. Copy in new file to a test site
2. Visit backend and switch between WC and CC

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Change compat plugin warning message to say no data lost if deleting WC.
