### PR TITLE
Further improvements to CC/Woo activation logic

### DIFF
--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -21,28 +21,47 @@ if ( ! function_exists( 'is_plugin_active' ) ) {
 }
 
 /**
- * Returns error when WooCommerce is detected among the files on the server.
+ * Shows an error message when WooCommerce is detected as currently active.
+ *
+ * WooCommerce and Classic Commerce cannot both be active at once.
  *
  * @return void
  */
 function cc_wc_already_active_notice() {
-	echo '<div class="error notice is_dismissible"><p>';
+	echo '<div class="notice error is-dismissible">';
+	echo '<p style="font-weight: bold">';
 	echo esc_html__( 'You must deactivate WooCommerce before activating Classic Commerce.', 'classic-commerce' );
-	echo '</p></div>';
+	echo '</p>';
+	echo '<p>';
+	echo esc_html__( 'Classic Commerce has been deactivated.', 'classic-commerce' );
+	echo '</p>';
+	echo '</div>';
 }
 
-if ( file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) && file_exists( WP_PLUGIN_DIR . '/woocommerce/includes/class-woocommerce.php' ) && is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+if (
+	file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) &&
+	// Make sure we are really looking at WooCommerce and not the compatibility plugin!
+	file_exists( WP_PLUGIN_DIR . '/woocommerce/includes/class-woocommerce.php' ) &&
+	is_plugin_active( 'woocommerce/woocommerce.php' )
+) {
 
-	// Woocommerce Files already exist. Show an admin notice.
+	// WooCommerce is already active. Show an admin notice.
 	add_action( 'admin_notices', 'cc_wc_already_active_notice' );
 
 	// Deactivate Classic Commerce.
 	deactivate_plugins( array( 'classic-commerce/classic-commerce.php' ) );
 
+	// Avoid showing a "Plugin activated" message in the admin screen.
+	// See src/wp-admin/plugins.php in core
+	unset( $_GET['activate'] );
+
 	// Do not proceed further with Classic Commerce loading.
-	return;
 
 } else {
+
+	////////////////////////////////////////////
+	// BEGIN CLASSIC COMMERCE LOADING PROCESS //
+	////////////////////////////////////////////
 
 	// Load the Update Client to manage Classic Commerce updates.
 	include_once dirname( __FILE__ ) . '/includes/class-wc-update-client.php';
@@ -72,4 +91,11 @@ if ( file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) && file_exist
 	// Global for backwards compatibility.
 	$GLOBALS['woocommerce'] = wc();
 
+	//////////////////////////////////////////
+	// END CLASSIC COMMERCE LOADING PROCESS //
+	//////////////////////////////////////////
+
 }
+
+// Do not add any new code here!  All code required to load Classic Commerce
+// must go inside the "CLASSIC COMMERCE LOADING PROCESS" block above.

--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -29,11 +29,11 @@ if ( ! function_exists( 'is_plugin_active' ) ) {
  */
 function cc_wc_already_active_notice() {
 	echo '<div class="notice error is-dismissible">';
-	echo '<p style="font-weight: bold">';
+	echo '<p><strong>';
 	echo esc_html__( 'You must deactivate WooCommerce before activating Classic Commerce.', 'classic-commerce' );
-	echo '</p>';
+	echo '</strong></p>';
 	echo '<p>';
-	echo esc_html__( 'Classic Commerce has been deactivated.', 'classic-commerce' );
+	echo esc_html__( 'Classic Commerce has not been activated.', 'classic-commerce' );
 	echo '</p>';
 	echo '</div>';
 }

--- a/classic-commerce.php
+++ b/classic-commerce.php
@@ -38,6 +38,8 @@ function cc_wc_already_active_notice() {
 	echo '</div>';
 }
 
+// Check if WooCommerce is already active.  In this case we need to block
+// Classic Commerce from being activated to avoid fatal errors.
 if (
 	file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) &&
 	// Make sure we are really looking at WooCommerce and not the compatibility plugin!
@@ -52,7 +54,7 @@ if (
 	deactivate_plugins( array( 'classic-commerce/classic-commerce.php' ) );
 
 	// Avoid showing a "Plugin activated" message in the admin screen.
-	// See src/wp-admin/plugins.php in core
+	// See also src/wp-admin/plugins.php in core.
 	unset( $_GET['activate'] );
 
 	// Do not proceed further with Classic Commerce loading.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR seeks to improve several aspects of the logic for deactivating Classic Commerce if WooCommerce is still active:

- Code structure and the accuracy of related code comments
- Notice appearance and clarity
- Correct `is_dismissible` notice class to `is-dismissible` so that the notice will have an (X) button to close it
- Remove an inaccurate notice that says "Plugin activated" when Classic Commerce really hasn't been activated. For how/why this works, see: https://github.com/ClassicPress/ClassicPress/blob/1.1.2+dev/src/wp-admin/plugins.php#L507-L508

Follow-up to #165.

#### Screenshot - before:

![2020-01-11T22-30-38Z](https://user-images.githubusercontent.com/227022/72211378-4b4f2800-34c2-11ea-83ed-71c4cc219d5d.png)

#### Screenshot - after:

![2020-01-11T22-31-09Z](https://user-images.githubusercontent.com/227022/72211380-4f7b4580-34c2-11ea-8385-c271d4476235.png)

### How to test the changes in this Pull Request:

1. Activate WooCommerce and deactivate Classic Commerce
2. Try to activate Classic Commerce
3. You should see the same notices as in the "After" screenshot above.

### Other information:

A future enhancement to consider would be adding a button to this notice that will deactivate WooCommerce and activate Classic Commerce. This should help users achieve a clean switch-over to Classic Commerce with no downtime.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

Further improvements to CC/Woo activation logic