### PR TITLE
Fix for CC admin menu icon display issues

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -175,6 +175,15 @@ final class WooCommerce {
 		add_action( 'init', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
+		add_action( 'admin_head', array( $this, 'load_icon_style' ) );
+	}
+	
+	/**
+	 * Some plugins block loading of menu.css causing the CC menu icon to display incorrectly.
+	 * Here we add the necessary style to ensure the icon style is loaded.
+	 */
+	public function load_icon_style() {
+		echo '<style>#adminmenu #toplevel_page_woocommerce .wp-menu-image img{max-width:20px;height:20px;margin-top:-3px}</style>';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Bulletproof Security (BPS) plugin has been found to block CC's menu.css from loading when the BPS menu is active. This results in the CC menu icon being displayed incorrectly. There may be other as-yet-unknown cases of plugins with similar problems. Loading the icon style rule separately in the \<head\> ensures we retain an element of control over how the icon displays.

Closes #172  .

### How to test the changes in this Pull Request:

1. Install and activate Bulletproof Security (BPS)
2. Click on BPS menu
3. CC icon should not change

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix for CC admin menu icon display issues caused by menu.css being blocked by certain plugins.
