### PR TITLE
Prevent the compatibility plugin notice from appearing when it shouldn't

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -361,12 +361,28 @@ class WC_Admin_Notices {
 	}
 
 	/**
-	 * Notice for requiring the Classic Commerce compatibility plugin to run Woocommerce specific extensions.
+	 * Notice for requiring the Classic Commerce compatibility plugin to run
+	 * some WooCommerce-specific extensions.
+	 *
+	 * See: https://github.com/Classic-Commerce/cc-compat-woo
 	 */
 	public static function require_compat_plugin_notice() {
-		if ( ! defined( 'CCWOOADDONSCOMPAT_VERSION' ) ) {
-			include dirname( __FILE__ ) . '/views/html-notice-require-compat-plugin.php';
+		if ( defined( 'CCWOOADDONSCOMPAT_VERSION' ) ) {
+			// The compatibility plugin is already installed.
+			return;
 		}
+
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			// The current user cannot manage plugins.  Don't show them a
+			// notice they can't act on.
+		}
+
+		if ( get_user_meta( get_current_user_id(), 'dismissed_require_compat_plugin_notice', true ) ) {
+			// The current user has already dismissed this notice.
+			return;
+		}
+
+		include dirname( __FILE__ ) . '/views/html-notice-require-compat-plugin.php';
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -375,6 +375,7 @@ class WC_Admin_Notices {
 		if ( ! current_user_can( 'activate_plugins' ) ) {
 			// The current user cannot manage plugins.  Don't show them a
 			// notice they can't act on.
+			return;
 		}
 
 		if ( get_user_meta( get_current_user_id(), 'dismissed_require_compat_plugin_notice', true ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Do not re-activate the dismissed compatibility plugin notice after switching themes or installing a new version of CC.

Fixes #180.

### How to test the changes in this Pull Request:

1. Set up a test site with the CC compatibility plugin notice present.
2. Dismiss the notice.
3. Switch to a different theme.
4. Return to the dashboard. You should not see the compatibility plugin notice any longer.

If you've already dismissed the compatibility plugin notice, you will need to reset a couple of things (or just set up a new site):

- Reset the `woocommerce_admin_notices` option. Switching to a different theme will do this.
- Remove the `dismissed_require_compat_plugin_notice` meta key for your user. I used WP-CLI and `wp user meta delete 1 dismissed_require_compat_plugin_notice` but any other method will work too.