### PR TITLE
Update compatibility notice wording

### DIFF
--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -15,17 +15,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p>
 		<?php
 		/*Translators: Notice for Compatibility plugin need.*/
-		echo sprintf( wp_kses( __( 'Are you installing WooCommerce specific extensions? You might require the <a href="%s">compatibility plugin</a>.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'admin.php?page=wc-addons#cc-compat' ) ) );
+		echo sprintf( wp_kses( __( 'Are you using WooCommerce-specific extensions? They might require the <a href="%s">compatibility plugin</a> in order to work correctly.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'admin.php?page=wc-addons#cc-compat' ) ) );
 		?>
 	</p>
 
 	<p>
 		<?php
 		/*Translators: Warning to delete WooCommerce.*/
-		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first before installing and activating the Compatibility Plugin. Deleting WooCommerce will not remove your products, settings and other data.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
+		echo sprintf( wp_kses( __( 'Make sure to <a href="%s">delete WooCommerce</a> first (or rename its plugin folder) before installing and activating the compatibility plugin. Deleting WooCommerce will not remove your products, settings or any other data.', 'classic-commerce' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'plugins.php' ) ) );
 		?>
 	</p>
 
-	<p class="submit"><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( 'https://github.com/Classic-Commerce/cc-compat-woo/releases' ); ?>" class="button-primary"><?php esc_html_e( 'Download compatibility plugin.', 'classic-commerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'require_compat_plugin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'classic-commerce' ); ?></a></p>
+	<p class="submit"><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( 'https://github.com/Classic-Commerce/cc-compat-woo/releases/latest' ); ?>" class="button-primary"><?php esc_html_e( 'Download Compatibility Plugin', 'classic-commerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'require_compat_plugin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'classic-commerce' ); ?></a></p>
 	
 </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Improve the wording of the compatibility plugin notice. Also update the "download" button to point to only the latest release on GitHub, instead of the list of all releases.

### Screenshot - before:

![2020-01-17T23-05-14Z](https://user-images.githubusercontent.com/227022/72652407-8b108680-397e-11ea-8bfd-9d1fcbdb3131.png)

### Screenshot - after:

![2020-01-17T23-04-56Z](https://user-images.githubusercontent.com/227022/72652411-9368c180-397e-11ea-9ec6-eabfb4803aaa.png)