### PR TITLE
Update the GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,3 @@ Closes # .
 * [ ] Have you successfully ran tests with your changes locally?
 
 <!-- Mark completed items with an [x] -->
-
-### Changelog entry
-
-> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,10 +20,19 @@ Closes # .
 2.
 3.
 
+### Screenshot - before:
+
+<!-- Upload a screenshot(s) of the relevant section(s) of the UI before your changes. -->
+
+### Screenshot - after:
+
+<!-- Upload a screenshot(s) of the relevant section(s) of the UI after your changes. -->
+
 ### Other information:
 
 * [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
 * [ ] Have you written new tests for your changes, as applicable?
 * [ ] Have you successfully ran tests with your changes locally?
+* [ ] Have you included screenshots before/after your changes, if applicable?
 
 <!-- Mark completed items with an [x] -->


### PR DESCRIPTION
This PR makes the following changes to the GitHub PR template that appears when you make a new PR:

- Remove the "Changelog entry" section from the PR template. As discussed on Slack, this should be the same as the PR title, so it doesn't add any extra value to require this separately.
- Add sections prompting for screenshots before/after your changes, if applicable.