### PR TITLE
Ignore coding style checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
   - php: 7.4snapshot
     env: CP_VERSION=latest WP_MULTISITE=0
   allow_failures:
+  - env: CP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1
   - env: CP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   - env: CP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
   - php: 7.4snapshot

--- a/tests/README.md
+++ b/tests/README.md
@@ -85,6 +85,8 @@ Code style is automatically checked for each pull request, in all files that wer
 ./vendor/bin/tests/bin/local-phpcs.sh
 ```
 
+Correct code style is **encouraged** but not currently required, due to the high number of pre-existing violations that appear whenever a file is modified.
+
 ## Code Coverage
 
 Code coverage is available on [Scrutinizer](https://scrutinizer-ci.com/g/woocommerce/woocommerce/) and [Code Climate](https://codeclimate.com/github/woocommerce/woocommerce) which receives updated data after each Travis build.


### PR DESCRIPTION
As discussed in Slack: disable the coding standards checks because we don't want to be dealing with large numbers of pre-existing violations for just about every PR.