### PR TITLE
Add title and Travis badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!---<p align="center"><a href="https://woocommerce.com/"><img src="https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png" alt="WooCommerce"></a></p>-->
+# Classic Commerce [![Build status](https://img.shields.io/travis/ClassicPress-research/classic-commerce/develop.svg?style=flat)](https://travis-ci.org/ClassicPress-research/classic-commerce)
 
 Welcome to the Classic Commerce repository on GitHub. This is a fork of Woocommerce and is still in development. 
 


### PR DESCRIPTION
This PR adds a main title and a Travis badge to the readme.

We should always keep the build passing, so it should look like this:

![2020-01-22T16-31-54Z](https://user-images.githubusercontent.com/227022/72913228-c15e5500-3d34-11ea-96f9-fb2122fdabad.png)
