### PR TITLE
Don't use the GitHub API to get the latest ClassicPress version

### DIFF
--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -35,9 +35,14 @@ set -ex
 if [[ "$CP_VERSION" == latest ]]; then
 	# Find the version number of the latest release
 	download \
-		https://api.github.com/repos/ClassicPress/ClassicPress-release/releases/latest \
+		https://www.classicpress.net/latest.json \
 		"$TMPDIR/cp-latest.json"
-	CP_VERSION="$(grep -Po '"tag_name":\s*"[^"]+"' "$TMPDIR/cp-latest.json" | cut -d'"' -f4)"
+	CP_VERSION="$(grep -Po '"version":\s*"[^"]+"' "$TMPDIR/cp-latest.json" | cut -d'"' -f4)"
+	if [ -z "$CP_VERSION" ]; then
+		echo "ClassicPress version not detected correctly!"
+		cat "$TMPDIR/cp-latest.json"
+		exit 1
+	fi
 elif ! [[ "$CP_VERSION" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
 	echo "ClassicPress version number not supported: $CP_VERSION"
 	exit 1


### PR DESCRIPTION
The GitHub API has a pretty strict rate limit for unauthenticated requests, which Travis CI appears to be hitting sometimes.  This is the cause of the latest build failure on https://github.com/ClassicPress-research/classic-commerce/pull/189 ([build log](https://travis-ci.com/ClassicPress-research/classic-commerce/jobs/278424886)).

Now that https://github.com/ClassicPress/ClassicPress-Network/issues/52 is done, we can use our own API endpoint to get the latest version of ClassicPress instead.