### PR TITLE
Minor fixes to the local-phpcs script to check code style

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -82,7 +82,7 @@ Classic Commerce uses `phpcs` and the WooCommerce coding style rules, with a few
 Code style is automatically checked for each pull request, in all files that were modified in that pull request.  If you'd like to check the code style locally for the files you've modified, you can change to the plugin root directory and run the `tests/bin/local-phpcs.sh` script:
 
 ```
-./vendor/bin/tests/bin/local-phpcs.sh
+./tests/bin/local-phpcs.sh
 ```
 
 Correct code style is **encouraged** but not currently required, due to the high number of pre-existing violations that appear whenever a file is modified.

--- a/tests/bin/local-phpcs.sh
+++ b/tests/bin/local-phpcs.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
+CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$(git merge-base HEAD upstream/develop)" | grep '\.php$')"
+
 set -e
 
-CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$(git merge-base HEAD upstream/develop)" | grep '\.php$')"
 IGNORE="tests/cli/,includes/libraries/,includes/api/legacy/"
 
 if [ "$CHANGED_FILES" == "" ]; then
-	echo "No changed files!"
+	echo "You haven't modified any PHP files!"
 else
 	for f in $CHANGED_FILES; do
 		php -l -d display_errors=0 "$f"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [ClassicCommerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix a couple of minor issues with the `local-phpcs.sh` script that you can use to check the code style for any files you modified:

- Fix the path to the script in the documentation
- Fix the script's output and exit code when no PHP files have been modified

Quick follow-up to #174.

### How to test the changes in this Pull Request:

1. Follow the instructions in `tests/README.md` to install the dependencies and run the `local-phpcs.sh` script, without modifying any PHP files in your current branch. Verify that the script runs as documented and prints an appropriate message.
2. Modify a PHP file and try again. Verify that the file(s) you modified are checked for syntax and code style errors.