### PR TITLE
Fix broken look in admin notice

### DIFF
--- a/includes/admin/views/html-notice-require-compat-plugin.php
+++ b/includes/admin/views/html-notice-require-compat-plugin.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<div id="message" class="updated woocommerce-message wc-connect">
+<div id="message" class="updated wc-connect">
 
 	<p>
 		<?php


### PR DESCRIPTION
### All Submissions:

Removing the `woocommerce-message` class fixes this. It has a restricted width.

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #203 .

### How to test the changes in this Pull Request:

1. Install CC
2. Check the admin notice requiring Compat plugin install

### Screenshot - before:
![Screenshot 2020-01-26 at 18 43 26](https://user-images.githubusercontent.com/7713923/73137940-58494b00-406e-11ea-9f1f-e019fc6e623c.png)

### Screenshot - after:
![Screenshot 2020-01-26 at 18 43 42](https://user-images.githubusercontent.com/7713923/73137948-6a2aee00-406e-11ea-85f3-e84768cf011b.png)
