### PR TITLE
Add 404 check when creating add to cart url for single products.

### DIFF
--- a/includes/class-wc-product-simple.php
+++ b/includes/class-wc-product-simple.php
@@ -39,8 +39,15 @@ class WC_Product_Simple extends WC_Product {
 	 * @return string
 	 */
 	public function add_to_cart_url() {
-		$url = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg( 'added-to-cart', add_query_arg( 'add-to-cart', $this->id ) ) : get_permalink( $this->id );
-
+		$url = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg(
+			'added-to-cart',
+			add_query_arg(
+				array(
+					'add-to-cart' => $this->get_id(),
+				),
+				( function_exists( 'is_feed' ) && is_feed() ) || ( function_exists( 'is_404' ) && is_404() ) ? $this->get_permalink() : ''
+			)
+		) : $this->get_permalink();
 		return apply_filters( 'woocommerce_product_add_to_cart_url', $url, $this );
 	}
 

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -585,7 +585,8 @@ function wc_disable_author_archives_for_customers() {
 		$user = get_user_by( 'id', $author );
 
 		if ( user_can( $user, 'customer' ) && ! user_can( $user, 'edit_posts' ) ) {
-			wp_redirect( wc_get_page_permalink( 'shop' ) );
+			wp_safe_redirect( wc_get_page_permalink( 'shop' ) );
+			exit;
 		}
 	}
 }

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -585,8 +585,7 @@ function wc_disable_author_archives_for_customers() {
 		$user = get_user_by( 'id', $author );
 
 		if ( user_can( $user, 'customer' ) && ! user_can( $user, 'edit_posts' ) ) {
-			wp_safe_redirect( wc_get_page_permalink( 'shop' ) );
-			exit;
+			wp_redirect( wc_get_page_permalink( 'shop' ) );
 		}
 	}
 }


### PR DESCRIPTION
Backport Security Commit f7a5449 #214 

Ensure 404 pages with single product urls cannot be exploited using Open Redirect. [woocommerce/woocommerce@f7a5449](https://github.com/woocommerce/woocommerce/commit/f7a5449118bac7b19e1e3201e6c11d0ee9f461a1)