### PR TITLE
Security fix: Escape html entities before passing to WP/photoswipe

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1396,15 +1396,26 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
-	$image             = wp_get_attachment_image( $attachment_id, $image_size, false, array(
-		'title'                   => get_post_field( 'post_title', $attachment_id ),
-		'data-caption'            => get_post_field( 'post_excerpt', $attachment_id ),
-		'data-src'                => $full_src[0],
-		'data-large_image'        => $full_src[0],
-		'data-large_image_width'  => $full_src[1],
-		'data-large_image_height' => $full_src[2],
-		'class'                   => $main_image ? 'wp-post-image' : '',
-	) );
+	$image             = wp_get_attachment_image(
+		$attachment_id,
+		$image_size,
+		false,
+		apply_filters(
+			'woocommerce_gallery_image_html_attachment_image_params',
+			array(
+				'title'                   => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+				'data-caption'            => _wp_specialchars( get_post_field( 'post_excerpt', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+				'data-src'                => esc_url( $full_src[0] ),
+				'data-large_image'        => esc_url( $full_src[0] ),
+				'data-large_image_width'  => esc_attr( $full_src[1] ),
+				'data-large_image_height' => esc_attr( $full_src[2] ),
+				'class'                   => esc_attr( $main_image ? 'wp-post-image' : '' ),
+			),
+			$attachment_id,
+			$image_size,
+			$main_image
+		)
+	);
 
 	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 }


### PR DESCRIPTION
Backport of security update to `includes/wc-template-functions.php` from https://github.com/woocommerce/woocommerce/commit/ffa230de9091cde33f1d60ffc971533e8682ba8f

See also #214

### Files changed

includes/wc-template-functions.php