### PR TITLE
Security fix: Introduce file type check for tax rate importer

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -86,6 +86,7 @@ class WC_Product_CSV_Importer_Controller {
 	/**
 	 * Check whether a file is a valid CSV file.
 	 *
+	 * @todo Replace this method with wc_is_file_valid_csv() function.
 	 * @param string $file File path.
 	 * @param bool   $check_path Whether to also check the file is located in a valid location (Default: true).
 	 * @return bool

--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -200,8 +200,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	 * @return bool False if error uploading or invalid file, true otherwise
 	 */
 	public function handle_upload() {
-		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Tax_Rate_Importer::dispatch()
-		$file_url = isset( $_POST['file_url'] ) ? wc_clean( wp_unslash( $_POST['file_url'] ) ) : '';
+		$file_url = isset( $_POST['file_url'] ) ? wc_clean( wp_unslash( $_POST['file_url'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Tax_Rate_Importer::dispatch()
 
 		if ( empty( $file_url ) ) {
 			$file = wp_import_handle_upload();
@@ -209,14 +208,24 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 			if ( isset( $file['error'] ) ) {
 				$this->import_error( $file['error'] );
 			}
+			
+			if ( ! wc_is_file_valid_csv( $file['file'], false ) ) {
+				// Remove file if not valid.
+				wp_delete_attachment( $file['id'], true );
+
+				$this->import_error( __( 'Invalid file type. The importer supports CSV and TXT file formats.', 'classic-commerce' ) );
+			}
 
 			$this->id = absint( $file['id'] );
 		} elseif ( file_exists( ABSPATH . $file_url ) ) {
+			if ( ! wc_is_file_valid_csv( ABSPATH . $file_url ) ) {
+				$this->import_error( __( 'Invalid file type. The importer supports CSV and TXT file formats.', 'classic-commerce' ) );
+			}
+
 			$this->file_url = esc_attr( $file_url );
 		} else {
 			$this->import_error();
 		}
-		// phpcs:enable
 
 		return true;
 	}

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -418,3 +418,47 @@ function wc_post_content_has_shortcode( $tag = '' ) {
 
 	return is_singular() && is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, $tag );
 }
+
+/**
+ * Check if a CSV file is valid.
+ *
+ * @since WC-3.6.5
+ * @param string $file       File name.
+ * @param bool   $check_path If should check for the path.
+ * @return bool
+ */
+function wc_is_file_valid_csv( $file, $check_path = true ) {
+	/**
+	 * Filter check for CSV file path.
+	 *
+	 * @since WC-3.6.4
+	 * @param bool $check_import_file_path If requires file path check. Defaults to true.
+	 */
+	$check_import_file_path = apply_filters( 'woocommerce_csv_importer_check_import_file_path', true );
+
+	if ( $check_path && $check_import_file_path && false !== stripos( $file, '://' ) ) {
+		return false;
+	}
+
+	/**
+	 * Filter CSV valid file types.
+	 *
+	 * @since 3.6.5
+	 * @param array $valid_filetypes List of valid file types.
+	 */
+	$valid_filetypes = apply_filters(
+		'woocommerce_csv_import_valid_filetypes',
+		array(
+			'csv' => 'text/csv',
+			'txt' => 'text/plain',
+		)
+	);
+
+	$filetype = wp_check_filetype( $file, $valid_filetypes );
+
+	if ( in_array( $filetype['type'], $valid_filetypes, true ) ) {
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
Backport for https://github.com/woocommerce/woocommerce/commit/737f6af5e8af27ae768d087e84c0303d8059281a

See also #214

Files affected:  
` includes/admin/importers/class-wc-product-csv-importer-controller.php`
` includes/admin/importers/class-wc-tax-rate-importer.php`
` includes/wc-conditional-functions.php`

Files not included:

` tests/unit-tests/util/conditional-functions.php`