### PR TITLE
Fix known compatibility issues with PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - vendor
     - $HOME/.composer/cache
 
-# Test main supported versions of PHP against latest WP 4.9.x.
+# Test main supported versions of PHP against the latest ClassicPress release.
 php:
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   - CP_VERSION=latest WP_MULTISITE=0
@@ -45,13 +46,10 @@ matrix:
   - name: "Unit tests code coverage"
     php: 7.3
     env: CP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  - php: 7.4snapshot
-    env: CP_VERSION=latest WP_MULTISITE=0
   allow_failures:
   - env: CP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1
   - env: CP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   - env: CP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
-  - php: 7.4snapshot
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ php:
   - 7.3
   - 7.4
 
+# TODO: Set CP_VERSION=latest after ClassicPress v1.2.0 is released with full
+# PHP 7.4 compatibility!
 env:
-  - CP_VERSION=latest WP_MULTISITE=0
+  - CP_VERSION=git-f765dbfa0 WP_MULTISITE=0
 
 # Additional tests against stable PHP (min version is 5.6)
 # and code coverage report.

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -471,9 +471,6 @@ class WC_Download_Handler {
 	 */
 	private static function check_server_config() {
 		wc_set_time_limit( 0 );
-		if ( function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime() && version_compare( phpversion(), '5.4', '<' ) ) {
-			set_magic_quotes_runtime( 0 ); // @codingStandardsIgnoreLine
-		}
 		if ( function_exists( 'apache_setenv' ) ) {
 			@apache_setenv( 'no-gzip', 1 ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_apache_setenv
 		}

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -193,7 +193,7 @@ final class WooCommerce {
 	 */
 	public function log_errors() {
 		$error = error_get_last();
-		if ( in_array( $error['type'], array( E_ERROR, E_PARSE, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ) ) ) {
+		if ( $error && in_array( $error['type'], array( E_ERROR, E_PARSE, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ) ) ) {
 			$logger = wc_get_logger();
 			$logger->critical(
 				/* translators: 1: error message 2: file name and path 3: line number */

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -773,9 +773,9 @@ if ( ! function_exists( 'wc_rgb_from_hex' ) ) {
 		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
 
 		$rgb      = array();
-		$rgb['R'] = hexdec( $color{0} . $color{1} );
-		$rgb['G'] = hexdec( $color{2} . $color{3} );
-		$rgb['B'] = hexdec( $color{4} . $color{5} );
+		$rgb['R'] = hexdec( $color[0] . $color[1] );
+		$rgb['G'] = hexdec( $color[2] . $color[3] );
+		$rgb['B'] = hexdec( $color[4] . $color[5] );
 
 		return $rgb;
 	}

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -709,7 +709,7 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 	);
 	$attachment = get_post( $attachment_id );
 
-	if ( $attachment ) {
+	if ( $attachment && 'attachment' === $attachment->post_type ) {
 		$props['title']   = wp_strip_all_tags( $attachment->post_title );
 		$props['caption'] = wp_strip_all_tags( $attachment->post_excerpt );
 		$props['url']     = wp_get_attachment_url( $attachment_id );

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -91,7 +91,7 @@ install_cp() {
 		download "$CP_DEV_ZIP_URL" "$CP_DEV_ZIP_PATH"
 		unzip -q "$CP_DEV_ZIP_PATH" -d "$CP_CORE_DIR"
 	fi
-	clean_github_download "$CP_CORE_DIR"
+	clean_github_download "$CP_CORE_DIR" true
 
 	download \
 		https://raw.github.com/markoheijnen/wp-mysqli/master/db.php \
@@ -107,10 +107,11 @@ clean_github_download() {
 	# GitHub downloads extract with a single folder inside, named based on the
 	# version downloaded. Get rid of this.
 	dir="$1"
+	remove_src_dir="$2"
 	mv "$dir" "$dir-old"
 	mv "$dir-old/ClassicPress-"* "$dir"
 	rmdir "$dir-old"
-	if [ -d "$dir/src" ]; then
+	if [ -d "$dir/src" ] && [ "$remove_src_dir" = true ]; then
 		# Development build - get rid of the 'src' directory too.
 		mv "$dir" "$dir-old"
 		mv "$dir-old/src" "$dir"
@@ -131,7 +132,7 @@ install_test_suite() {
 		mkdir -p "$CP_TESTS_DIR"
 		download "$CP_DEV_ZIP_URL" "$CP_DEV_ZIP_PATH"
 		unzip -q "$CP_DEV_ZIP_PATH" -d "$CP_DEV_PATH"
-		clean_github_download "$CP_DEV_PATH"
+		clean_github_download "$CP_DEV_PATH" false
 		cp -ar \
 			"$CP_DEV_PATH/tests/phpunit/includes" \
 			"$CP_DEV_PATH/tests/phpunit/data" \


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Fix curly brackets fatal error [and other notices/warnings/errors] in PHP 7.4

PHP used to allow both square brackets and curly braces to be used interchangeably for accessing array elements and string offsets. The curly bracket syntax is only allowed in a limited set of cases and can be confusing for people not used to it.

PHP 7.4 will deprecate the curly brace syntax for accessing array elements and string offsets and it is expected that support will be completely removed in PHP 8.0.
Ref: https://wiki.php.net/rfc/deprecate_curly_braces_array_access

See https://core.trac.wordpress.org/ticket/47751.

Closes #194.

### How to test the changes in this Pull Request:
1. Use a server with PHP 7.4
2. Turn on WP_DEBUG to true
3. Install CC (No errors, plugin installs well.)

### Screenshot - before:
![Screenshot 2020-02-25 at 09 19 13](https://user-images.githubusercontent.com/7713923/75220198-e7519c00-57af-11ea-9c49-711902fa5986.png)

### Screenshot - after:
![Screenshot 2020-02-25 at 09 33 25](https://user-images.githubusercontent.com/7713923/75221404-ce96b580-57b2-11ea-918a-6899a50e1ea6.png)

![Screenshot 2020-02-25 at 09 33 15](https://user-images.githubusercontent.com/7713923/75221410-d22a3c80-57b2-11ea-834f-dc6487139249.png)
