### PR TITLE
Security fix: Add 404 check when creating add to cart url for single …

### DIFF
--- a/includes/class-wc-product-simple.php
+++ b/includes/class-wc-product-simple.php
@@ -39,8 +39,15 @@ class WC_Product_Simple extends WC_Product {
 	 * @return string
 	 */
 	public function add_to_cart_url() {
-		$url = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg( 'added-to-cart', add_query_arg( 'add-to-cart', $this->id ) ) : get_permalink( $this->id );
-
+		$url = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg(
+			'added-to-cart',
+			add_query_arg(
+				array(
+					'add-to-cart' => $this->get_id(),
+				),
+				( function_exists( 'is_feed' ) && is_feed() ) || ( function_exists( 'is_404' ) && is_404() ) ? $this->get_permalink() : ''
+			)
+		) : $this->get_permalink();
 		return apply_filters( 'woocommerce_product_add_to_cart_url', $url, $this );
 	}
 


### PR DESCRIPTION
…products

Backport from https://github.com/woocommerce/woocommerce/commit/dc1438d707d13de985c908252a726dd7dc5f9011

See also #214

This PR also covers the following commits: 

- https://github.com/woocommerce/woocommerce/commit/badb135bd62ca5d11cf6a55220cee61180f8c00c
- https://github.com/woocommerce/woocommerce/commit/f7a5449118bac7b19e1e3201e6c11d0ee9f461a1

WC commits `badb135` and `f7a5449` are identical.

WC commit `dc1438d` includes the changes made in the above two commits as well as other changes, making `badb135` and `f7a5449` superfluous.

### Files changed

includes/class-wc-product-simple.php