### PR TITLE
Security fix: Exit after redirect in wc-user-functions.php

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -585,7 +585,8 @@ function wc_disable_author_archives_for_customers() {
 		$user = get_user_by( 'id', $author );
 
 		if ( user_can( $user, 'customer' ) && ! user_can( $user, 'edit_posts' ) ) {
-			wp_redirect( wc_get_page_permalink( 'shop' ) );
+			wp_safe_redirect( wc_get_page_permalink( 'shop' ) );
+			exit;
 		}
 	}
 }


### PR DESCRIPTION
Backport for WC https://github.com/woocommerce/woocommerce/commit/293d16f32528a56fd1e0f72b3605e17cfb78a6d5

Also covers https://github.com/woocommerce/woocommerce/commit/4d6ddf34294d2d1dcd75722cdb05e15d21dc6059, a duplicate of the above.

See also #214.

### Files changed
 includes/wc-user-functions.php
(function `wc_disable_author_archives_for_customers()`).