### PR TITLE
Fix build badge to update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Classic Commerce [![Build status](https://img.shields.io/travis/ClassicPress-research/classic-commerce/develop.svg?style=flat)](https://travis-ci.org/ClassicPress-research/classic-commerce)
+# Classic Commerce [![Build Status](https://travis-ci.com/ClassicPress-research/classic-commerce.svg?branch=master)](https://travis-ci.com/ClassicPress-research/classic-commerce)
 
 Welcome to the Classic Commerce repository on GitHub. This is a fork of WooCommerce and is still in development.
 


### PR DESCRIPTION
PR is to fix badge that shows Repo build status. Currently shows a failing status yet travis says otherwise on the build and test passing.

![Screenshot (68)](https://user-images.githubusercontent.com/7713923/80946791-7a820000-8df7-11ea-95cf-eb90b4055224.png)
