### PR TITLE
Change composer.json "type" back to "wordpress-plugin"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "classicpress-research/classic-commerce",
   "description": "A simple, powerful and independent e-commerce platform. Sell anything with ease.",
   "homepage": "https://github.com/ClassicPress-research/classic-commerce",
-  "type": "classicpress-plugin",
+  "type": "wordpress-plugin",
   "license": "GPL-3.0-or-later",
   "prefer-stable": true,
   "minimum-stability": "dev",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Classic Commerce Contributing guideline](https://github.com/ClassicPress-research/classic-commerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [repo standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes the `type` value in our `composer.json` file from `classicpress-plugin` back to `wordpress-plugin` which is recognized by the standard `composer` installation system. This will allow Classic Commerce to work seamlessly with Composer-based sites as described here: https://docs.classicpress.net/installing-classicpress/installing-with-composer/

This is for compatibility with Composer-based sites, since `wordpress-plugin` is a type recognized by `composer/installers` but `classicpress-plugin` is not:

https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md

> **Note:** You cannot use this to change the path of any package. This is only applicable to packages that require `composer/installers` and use a custom type that it handles.

Fixes #239.

### How to test the changes in this Pull Request:

1. Follow the instructions to set up a Bedrock-based ClassicPress site using Composer at https://docs.classicpress.net/installing-classicpress/installing-with-composer/#after-installation .
2. Add a new entry to the `repositories` section of your `composer.json` file as follows: https://github.com/nylen/cp-composer-cc/commit/effad0985c12666b357503fa2f460716a6ba1e90
3. Run `composer require classicpress-research/classic-commerce:v1.0.0-alpha.3` and note that Classic Commerce is installed into the `vendor` directory, instead of the `web/app/plugins/` directory as expected under this setup.
4. Run `composer remove classicpress-research/classic-commerce` and update the repository URL in your `composer.json` as follows: https://github.com/nylen/cp-composer-cc/commit/d38eb0f704a175a30a6f9b8b58076c32f887ab6e
5. Run `composer require 'classicpress-research/classic-commerce:dev-fix/composer-type#7f890d7'` to install the version of Classic Commerce from this PR.
6. Note that Classic Commerce is now installed under `web/app/plugins/classic-commerce/` as expected.